### PR TITLE
fix(popover): 'destroyOutsideClickHandler is not a function'

### DIFF
--- a/src/LumexUI/wwwroot/js/components/popover.bundle.js
+++ b/src/LumexUI/wwwroot/js/components/popover.bundle.js
@@ -1475,7 +1475,10 @@ async function initialize(id, options) {
 }
 
 function destroy() {
-    destroyOutsideClickHandler();
+    if (destroyOutsideClickHandler) {
+        destroyOutsideClickHandler();
+        destroyOutsideClickHandler = null;
+    }
 }
 
 const popover = {

--- a/src/LumexUI/wwwroot/js/components/popover.js
+++ b/src/LumexUI/wwwroot/js/components/popover.js
@@ -82,7 +82,10 @@ async function initialize(id, options) {
 }
 
 function destroy() {
-    destroyOutsideClickHandler();
+    if (destroyOutsideClickHandler) {
+        destroyOutsideClickHandler();
+        destroyOutsideClickHandler = null;
+    }
 }
 
 export const popover = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for the popover's destruction process to prevent potential errors when invoking the click handler.
	- Ensured that the click handler is only called if it has been set, improving the cleanup process and preventing memory leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->