### PR TITLE
feat(docs): Add warning about using Tailwind CSS v4.0

### DIFF
--- a/docs/LumexUI.Docs.Client/Components/Layouts/InstallationLayout.razor
+++ b/docs/LumexUI.Docs.Client/Components/Layouts/InstallationLayout.razor
@@ -36,6 +36,13 @@
                     </li>
                 </ul>
             </DocsSection>
+
+	        <Callout Variant="@CalloutVariant.Warning">
+		        Please be aware that LumexUI isn't fully compatible with Tailwind CSS v4.0 at this time. If this is the
+		        version you plan on using, proceed at your own risk. More information can be found in 
+		        <LumexLink Href="https://github.com/LumexUI/lumexui/issues/156"
+		                   External="true">this Github conversation</LumexLink>.
+	        </Callout>
             <LumexDivider />
         </div>
 

--- a/docs/LumexUI.Docs.Client/Pages/Getting Started/Installation.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Getting Started/Installation.razor
@@ -18,7 +18,7 @@
             Code = new CodeBlock("tailwind.config.js", "installationConfig"),
             Body = @<text>
                 <p>
-                    LumexUI is built on top of Tailwind CSS. To install, follow the official <LumexLink Href="https://tailwindcss.com/docs/installation" External="@true">installation guide</LumexLink>. Then, modify the <code>tailwind.config.js</code> file.
+                    LumexUI is built on top of Tailwind CSS. To install, follow the official <LumexLink Href="https://v3.tailwindcss.com/docs/installation" External="@true">installation guide</LumexLink>. Then, modify the <code>tailwind.config.js</code> file.
                 </p>
                 <i>
                     Note: the <code>PATH_TO_NUGET</code> is the NuGet package path on the machine.

--- a/docs/LumexUI.Docs.Client/Pages/Getting Started/Installation.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Getting Started/Installation.razor
@@ -21,7 +21,7 @@
                     LumexUI is built on top of Tailwind CSS. To install, follow the official <LumexLink Href="https://v3.tailwindcss.com/docs/installation" External="@true">installation guide</LumexLink>. Then, modify the <code>tailwind.config.js</code> file.
                 </p>
                 <i>
-                    Note: the <code>PATH_TO_NUGET</code> is the NuGet package path on the machine.
+                    Note: the <code>PATH_TO_NUGET</code> is the <LumexLink Href="https://learn.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders#:~:text=Windows%3A%20%25userprofile,~/.nuget/packages" External="@true">NuGet package path on the machine</LumexLink>.
                 </i>
                 </text>
         },


### PR DESCRIPTION
Add warning about using Tailwind CSS v4.0

<!-- Thank you for submitting a pull request to our repo! -->

## Description

This PR adds a warning in the installation steps about limited compatibility with Tailwind CSS v4.0.

![image](https://github.com/user-attachments/assets/9d2486d8-1471-4a88-9ac5-f962bde80754)

Partially closes #156 

### What's been done?
* Add a warning in the installation steps. This warning references the conversation happening in #157 
* Point to the official installation guide for Tailwind CSS v3.* for the time being
  
### Checklist
- [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
- [x] I have included inline docs for my changes, where applicable.
- [x] I have added, updated or removed tests according to my changes.
- [x] All tests are passing.
- [x] There's an open issue for the PR that I am making.

### Additional Notes
<!-- 
    Any additional information that may be relevant to the 
    reviewer or the pull request as a whole. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Added a warning `Callout` component in the installation layout to highlight LumexUI's compatibility issues with Tailwind CSS v4.0.
  - Updated Tailwind CSS installation guide URL to point to v3 documentation.
  - Enhanced installation instructions with a hyperlink to relevant Microsoft documentation for the NuGet package path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->