### PR TITLE
fix(switch): ensure secondary color styles apply properly  

### DIFF
--- a/src/LumexUI/Styles/Switch.cs
+++ b/src/LumexUI/Styles/Switch.cs
@@ -100,7 +100,7 @@ internal readonly record struct Switch
         return ElementClass.Empty()
             .Add( "group-data-[checked=true]:bg-default-400 group-data-[checked=true]:text-default-foreground", when: color is ThemeColor.Default )
             .Add( "group-data-[checked=true]:bg-primary group-data-[checked=true]:text-primary-foreground", when: color is ThemeColor.Primary )
-            .Add( "group-data-[checked=true]:bg-secodary group-data-[checked=true]:text-secondary-foreground", when: color is ThemeColor.Secondary )
+            .Add( "group-data-[checked=true]:bg-secondary group-data-[checked=true]:text-secondary-foreground", when: color is ThemeColor.Secondary )
             .Add( "group-data-[checked=true]:bg-success group-data-[checked=true]:text-success-foreground", when: color is ThemeColor.Success )
             .Add( "group-data-[checked=true]:bg-warning group-data-[checked=true]:text-warning-foreground", when: color is ThemeColor.Warning )
             .Add( "group-data-[checked=true]:bg-danger group-data-[checked=true]:text-danger-foreground", when: color is ThemeColor.Danger )


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo! -->

## Description

Closes #179 

Ensures that `ThemeColor.Secondary` correctly applies styles to `LumexSwitch`.

### What's been done?

Fixed a typo in the LumexSwitch styles.
  
### Checklist
<!-- Make sure that you've checked all the items below before submitting the pull request. -->
- [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
- [x] I have included inline docs for my changes, where applicable.
- [x] I have added, updated or removed tests according to my changes.
- [x] All tests are passing.
- [x] There's an open issue for the PR that I am making.

### Additional Notes
<!-- 
    Any additional information that may be relevant to the 
    reviewer or the pull request as a whole. 
-->
