### PR TITLE
fix(navbar): add a check before toggling navbar menu on navigation

### DIFF
--- a/src/LumexUI/Components/Navbar/LumexNavbarMenu.razor.cs
+++ b/src/LumexUI/Components/Navbar/LumexNavbarMenu.razor.cs
@@ -17,55 +17,60 @@ namespace LumexUI;
 [CompositionComponent( typeof( LumexNavbar ) )]
 public partial class LumexNavbarMenu : LumexComponentBase, IDisposable
 {
-    /// <summary>
-    /// Gets or sets content to be rendered inside the navbar menu.
-    /// </summary>
+	/// <summary>
+	/// Gets or sets content to be rendered inside the navbar menu.
+	/// </summary>
 	[Parameter] public RenderFragment? ChildContent { get; set; }
 
-    [CascadingParameter] internal NavbarContext Context { get; set; } = default!;
+	[CascadingParameter] internal NavbarContext Context { get; set; } = default!;
 
-    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+	[Inject] private NavigationManager NavigationManager { get; set; } = default!;
 
-    internal bool Expanded { get; private set; }
+	internal bool Expanded { get; private set; }
 
-    private protected override string? RootClass =>
-        TwMerge.Merge( Navbar.GetMenuStyles( this ) );
+	private protected override string? RootClass =>
+		TwMerge.Merge( Navbar.GetMenuStyles( this ) );
 
-    private protected override string? RootStyle =>
-        ElementStyle.Empty()
-            .Add( "--navbar-height", $"{Context.Owner.Height}" )
-            .Add( base.RootStyle )
-            .ToString();
+	private protected override string? RootStyle =>
+		ElementStyle.Empty()
+			.Add( "--navbar-height", $"{Context.Owner.Height}" )
+			.Add( base.RootStyle )
+			.ToString();
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="LumexNavbarMenu"/>.
-    /// </summary>
-    public LumexNavbarMenu()
-    {
-        As = "ul";
-    }
+	/// <summary>
+	/// Initializes a new instance of the <see cref="LumexNavbarMenu"/>.
+	/// </summary>
+	public LumexNavbarMenu()
+	{
+		As = "ul";
+	}
 
-    /// <inheritdoc />
-    protected override void OnInitialized()
-    {
-        ContextNullException.ThrowIfNull( Context, nameof( LumexNavbarMenu ) );
+	/// <inheritdoc />
+	protected override void OnInitialized()
+	{
+		ContextNullException.ThrowIfNull( Context, nameof( LumexNavbarMenu ) );
 
-        Context.RegisterMenu( this );
-        NavigationManager.LocationChanged += HandleLocationChanged;
-    }
+		Context.RegisterMenu( this );
+		NavigationManager.LocationChanged += HandleLocationChanged;
+	}
 
-    internal void Toggle()
-    {
-        Expanded = !Expanded;
-        StateHasChanged();
-    }
+	internal void Toggle()
+	{
+		Expanded = !Expanded;
+		StateHasChanged();
+	}
 
-    private void HandleLocationChanged( object? sender, LocationChangedEventArgs e ) 
-        => Toggle();
+	private void HandleLocationChanged( object? sender, LocationChangedEventArgs e )
+	{
+		if( Expanded )
+		{
+			Toggle();
+		}
+	}
 
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        NavigationManager.LocationChanged -= HandleLocationChanged;
-    }
+	/// <inheritdoc />
+	public void Dispose()
+	{
+		NavigationManager.LocationChanged -= HandleLocationChanged;
+	}
 }

--- a/tests/LumexUI.Tests/Components/Navbar/NavbarTests.razor
+++ b/tests/LumexUI.Tests/Components/Navbar/NavbarTests.razor
@@ -85,6 +85,38 @@
     }
 
     [Fact]
+    public void ShouldNotOpenMenuOnNavigation()
+    {
+        var navigationManager = Services.GetRequiredService<FakeNavigationManager>();
+        string[] menuItems = ["item1", "item2", "item3", "item4", "item5"];
+
+        var cut = Render(
+            @<LumexNavbar>
+                <LumexNavbarMenuToggle />
+                <LumexNavbarContent>
+                    <LumexNavbarItem>Dashboard</LumexNavbarItem>
+                    <LumexNavbarItem>Team</LumexNavbarItem>
+                    <LumexNavbarItem>Deployments</LumexNavbarItem>
+                    <LumexNavbarItem>Activity</LumexNavbarItem>
+                    <LumexNavbarItem>Settings</LumexNavbarItem>
+                </LumexNavbarContent>
+                <LumexNavbarMenu>
+                    @foreach( var item in menuItems )
+                    {
+                        <LumexNavbarMenuItem>@item</LumexNavbarMenuItem>
+                    }
+                </LumexNavbarMenu>
+            </LumexNavbar>
+        );
+
+        navigationManager.NavigateTo( "somewhere" );
+
+        var menu = cut.FindComponent<LumexNavbarMenu>();
+
+        menu.Instance.Expanded.Should().BeFalse();
+    }
+
+    [Fact]
     public void ShouldNotRenderContextualComponentsAlone()
     {
         var action1 = () => Render(@<LumexNavbarBrand />);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo! -->

## Description
<!--- 
    Provide a brief description of the changes in this pull request
    and mention related issues that this PR addresses or closes.
-->
Closes #203 

This PR fixes a logical mistake that caused `LumexNavbarMenu` to toggle on navigation. The initial logic was intended to close the menu, but the check for the expanded state was missing.

### What's been done?
<!-- List the specific changes made in bullet-point format. -->

- Added a check to ensure the menu is open before toggling (closing) the navbar menu on navigation
  
### Checklist
<!-- Make sure that you've checked all the items below before submitting the pull request. -->
- [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
- [x] I have included inline docs for my changes, where applicable.
- [x] I have added, updated or removed tests according to my changes.
- [x] All tests are passing.
- [x] There's an open issue for the PR that I am making.

### Additional Notes
<!-- 
    Any additional information that may be relevant to the 
    reviewer or the pull request as a whole. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code formatting and structure for enhanced clarity without altering the user experience.
- **Tests**
  - Introduced a new test to confirm that the navigation menu remains closed during page transitions for added reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->