### PR TITLE
feat(components): add Tooltip component

### DIFF
--- a/docs/LumexUI.Docs.Client/Common/Navigation/NavigationStore.cs
+++ b/docs/LumexUI.Docs.Client/Common/Navigation/NavigationStore.cs
@@ -46,7 +46,8 @@ public class NavigationStore
 			.Add( new( nameof( LumexSpinner ), ComponentStatus.New ) )
 			.Add( new( nameof( LumexSwitch ) ) )
 			.Add( new( nameof( LumexTabs ) ) )
-			.Add( new( nameof( LumexTextbox ) ) );
+			.Add( new( nameof( LumexTextbox ) ) )
+			.Add( new( nameof( LumexTooltip ), ComponentStatus.New ) );
 
 	private static NavigationCategory ComponentsApiCategory =>
 		new NavigationCategory( "Components API", Icons.Rounded.Manufacturing )

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Arrow.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Arrow.razor
@@ -1,0 +1,3 @@
+﻿<LumexTooltip Content="@("I am a tooltip")" ShowArrow="@true">
+    <LumexButton>Hover me</LumexButton>
+</LumexTooltip>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Colors.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Colors.razor
@@ -1,0 +1,8 @@
+﻿@foreach( var color in Enum.GetValues<ThemeColor>()[1..] )
+{
+    var colorText = color.ToString();
+
+    <LumexTooltip Content="@colorText" Color="@color">
+        <LumexButton Color="@color">@colorText</LumexButton>
+    </LumexTooltip>
+}

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/CustomContent.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/CustomContent.razor
@@ -1,0 +1,11 @@
+﻿<LumexTooltip Content="@_customContent" ShowArrow="@true">
+    <LumexButton>Hover me</LumexButton>
+</LumexTooltip>
+
+@code {
+    private RenderFragment _customContent =
+        @<div class="px-1 py-2">
+            <div class="text-small font-bold">Custom content</div>
+            <div class="text-tiny">This is a custom tooltip content</div>
+        </div>;
+}

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/CustomContent.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/CustomContent.razor
@@ -1,4 +1,4 @@
-﻿<LumexTooltip Content="@_customContent" ShowArrow="@true">
+﻿<LumexTooltip Content="@_customContent">
     <LumexButton>Hover me</LumexButton>
 </LumexTooltip>
 

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/CustomStyles.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/CustomStyles.razor
@@ -1,0 +1,17 @@
+﻿<LumexTooltip Content="@("I am a tooltip")"
+              Placement="@TooltipPlacement.Right"
+              ShowArrow="@true"
+              Classes="@_classes">
+    <LumexButton>Hover me</LumexButton>
+</LumexTooltip>
+
+@code {
+    private TooltipSlots _classes = new()
+    {
+        Content = ElementClass.Empty()
+            .Add( "py-2 px-4 shadow-xl" )
+            .Add( "text-black bg-gradient-to-br from-white to-default-400" )
+            .ToString(),
+        Arrow = "bg-default-400"
+    };
+}

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Offset.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Offset.razor
@@ -1,11 +1,23 @@
-﻿<LumexTooltip Content="@("I am a tooltip")">
-    <LumexButton>Default offset (8)</LumexButton>
+﻿<LumexTooltip Content="@("I am a tooltip")"
+              Color="@ThemeColor.Warning">
+    <LumexButton Color="@ThemeColor.Warning"
+                 Variant="@Variant.Flat">
+        Default offset (8)
+    </LumexButton>
 </LumexTooltip>
 
-<LumexTooltip Content="@("I am a tooltip")" Offset="16">
-    <LumexButton>16 offset</LumexButton>
+<LumexTooltip Content="@("I am a tooltip")" Offset="16"
+              Color="@ThemeColor.Warning">
+    <LumexButton Color="@ThemeColor.Warning"
+                 Variant="@Variant.Flat">
+        16 offset
+    </LumexButton>
 </LumexTooltip>
 
-<LumexTooltip Content="@("I am a tooltip")" Offset="-7">
-    <LumexButton>-7 offset</LumexButton>
+<LumexTooltip Content="@("I am a tooltip")" Offset="-7"
+              Color="@ThemeColor.Warning">
+    <LumexButton Color="@ThemeColor.Warning"
+                 Variant="@Variant.Flat">
+        -7 offset
+    </LumexButton>
 </LumexTooltip>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Offset.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Offset.razor
@@ -1,0 +1,11 @@
+﻿<LumexTooltip Content="@("I am a tooltip")">
+    <LumexButton>Default offset (8)</LumexButton>
+</LumexTooltip>
+
+<LumexTooltip Content="@("I am a tooltip")" Offset="16">
+    <LumexButton>16 offset</LumexButton>
+</LumexTooltip>
+
+<LumexTooltip Content="@("I am a tooltip")" Offset="-7">
+    <LumexButton>-7 offset</LumexButton>
+</LumexTooltip>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Placements.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Placements.razor
@@ -1,0 +1,12 @@
+﻿<div class="flex flex-wrap md:inline-grid md:grid-cols-3 gap-4">
+    @foreach( var placement in Enum.GetValues<TooltipPlacement>() )
+    {
+        var placementText = placement.ToString();
+
+        <LumexTooltip Content="@placementText" Placement="@placement">
+            <LumexButton Variant="@Variant.Flat" Color="@ThemeColor.Danger">
+                @placementText
+            </LumexButton>
+        </LumexTooltip>
+    }
+</div>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Placements.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Placements.razor
@@ -1,10 +1,13 @@
 ﻿<div class="flex flex-wrap md:inline-grid md:grid-cols-3 gap-4">
     @foreach( var placement in Enum.GetValues<TooltipPlacement>() )
     {
-        var placementText = placement.ToString();
+        var placementText = placement.ToDescription().Replace( "-", " " );
 
         <LumexTooltip Content="@placementText" Placement="@placement">
-            <LumexButton Variant="@Variant.Flat" Color="@ThemeColor.Danger">
+            <LumexButton Color="@ThemeColor.Danger"
+                         Variant="@Variant.Flat"
+                         FullWidth="@true"
+                         Class="capitalize">
                 @placementText
             </LumexButton>
         </LumexTooltip>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Radii.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Radii.razor
@@ -1,0 +1,10 @@
+﻿@foreach( var radius in Enum.GetValues<Radius>() )
+{
+    var radiusText = radius.ToString();
+
+    <LumexTooltip Content="@radiusText" Radius="@radius">
+        <LumexButton Variant="@Variant.Flat" Color="@ThemeColor.Secondary">
+            @radiusText
+        </LumexButton>
+    </LumexTooltip>
+}

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Shadows.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Shadows.razor
@@ -1,0 +1,10 @@
+﻿@foreach( var shadow in Enum.GetValues<Shadow>() )
+{
+    var shadowText = shadow.ToString();
+
+    <LumexTooltip Content="@shadowText" Shadow="@shadow">
+        <LumexButton Variant="@Variant.Flat" Color="@ThemeColor.Success">
+            @shadowText
+        </LumexButton>
+    </LumexTooltip>
+}

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Sizes.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Sizes.razor
@@ -1,0 +1,10 @@
+﻿@foreach( var size in Enum.GetValues<Size>() )
+{
+    var sizeText = size.ToString();
+
+    <LumexTooltip Content="@sizeText" Size="@size">
+        <LumexButton Color="@ThemeColor.Primary" Variant="@Variant.Flat">
+            @sizeText
+        </LumexButton>
+    </LumexTooltip>
+}

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/TwoWayDataBinding.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/TwoWayDataBinding.razor
@@ -1,0 +1,13 @@
+﻿<div class="flex flex-col gap-2">
+    <LumexTooltip Content="@("I am a tooltip")" @bind-Open="@_isOpen">
+        <LumexButton>Hover me</LumexButton>
+    </LumexTooltip>
+
+    <p class="text-small text-default-500">
+        Open: @(_isOpen ? "true" : "false")
+    </p>
+</div>
+
+@code {
+    private bool _isOpen;
+}

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Usage.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Examples/Usage.razor
@@ -1,0 +1,3 @@
+﻿<LumexTooltip Content="@("I am a tooltip")">
+    <LumexButton>Hover me</LumexButton>
+</LumexTooltip>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Arrow.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Arrow.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new( name: null, snippet: "Tooltip.Code.Arrow" )">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.Arrow />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Colors.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Colors.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new( name: null, snippet: "Tooltip.Code.Colors" )">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.Colors />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/CustomContent.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/CustomContent.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new( name: null, snippet: "Tooltip.Code.CustomContent" )">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.CustomContent />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/CustomStyles.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/CustomStyles.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new( name: null, snippet: "Tooltip.Code.CustomStyles" )">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.CustomStyles />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Offset.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Offset.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new( name: null, snippet: "Tooltip.Code.Offset" )">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.Offset />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Placements.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Placements.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new( name: null, snippet: "Tooltip.Code.Placements" )">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.Placements />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Radii.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Radii.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new( name: null, snippet: "Tooltip.Code.Radii" )">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.Radii />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Shadows.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Shadows.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new( name: null, snippet: "Tooltip.Code.Shadows" )">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.Shadows />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Sizes.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Sizes.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new( name: null, snippet: "Tooltip.Code.Sizes" )">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.Sizes />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/TwoWayDataBinding.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/TwoWayDataBinding.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new( name: null, snippet: "Tooltip.Code.TwoWayDataBinding" )">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.TwoWayDataBinding />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Usage.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/PreviewCodes/Usage.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new(name: null, snippet: "Tooltip.Code.Usage")">
+    <LumexUI.Docs.Client.Pages.Components.Tooltip.Examples.Usage />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Tooltip.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Tooltip/Tooltip.razor
@@ -1,0 +1,120 @@
+﻿@page "/docs/components/tooltip"
+@layout DocsContentLayout
+
+@using LumexUI.Docs.Client.Pages.Components.Tooltip.PreviewCodes
+
+<DocsSection Title="Usage">
+    <Usage />
+
+    <DocsSection Title="Colors">
+        <p>Use <Code>Color</Code> parameter to set the tooltip background color.</p>
+        <Colors />
+    </DocsSection>
+
+    <DocsSection Title="Sizes">
+        <p>Use <Code>Size</Code> parameter to adjust the font size of the tooltip.</p>
+        <Sizes />
+    </DocsSection>
+
+    <DocsSection Title="Radius">
+        <p>Use <Code>Radius</Code> parameter to control the border radius of the tooltip.</p>
+        <Radii />
+    </DocsSection>
+
+    <DocsSection Title="Shadows">
+        <p>Use <Code>Shadow</Code> parameter to apply a shadow to the tooltip.</p>
+        <Shadows />
+    </DocsSection>
+
+    <DocsSection Title="Placements">
+        <p>
+            Use <Code>Placement</Code> parameter to control
+            where the tooltip appears relative to the anchor element.
+        </p>
+        <Placements />
+    </DocsSection>
+
+    <DocsSection Title="Offset">
+        <p>
+            Use <Code>Offset</Code> parameter to set the distance
+            between the tooltip and the anchor.
+        </p>
+        <Offset />
+    </DocsSection>
+
+    <DocsSection Title="Arrow">
+        <p>Use <Code>Arrow</Code> parameter to toggle the display of the tooltip arrow.</p>
+        <Arrow />
+    </DocsSection>
+
+    <DocsSection Title="Custom Content">
+        <p>Use <Code>Content</Code> parameter to render custom markup content in the tooltip.</p>
+        <CustomContent />
+    </DocsSection>
+
+    <DocsSection Title="Two-way Data Binding">
+        <p>
+            Use <Code>@@bind-Value</Code> directive or <Code>Open</Code> and <Code>OpenChanged</Code>
+            parameters to manually control tooltip visibility.
+        </p>
+        <TwoWayDataBinding />
+    </DocsSection>
+</DocsSection>
+
+<DocsSlotsSection Slots="@_slots">
+    <div>
+        <h4 class="font-semibold">Tooltip</h4>
+        <ul>
+            <li><Code>Class</Code>: The CSS class names to style the tooltip wrapper.</li>
+            <li><Code>Classes</Code>: The CSS class names to style the tooltip slots.</li>
+        </ul>
+    </div>
+    <CustomStyles />
+</DocsSlotsSection>
+
+<DocsApiSection Components="@_apiComponents" />
+
+@code {
+    [CascadingParameter] private DocsContentLayout Layout { get; set; } = default!;
+
+    private readonly Heading[] _headings = new Heading[]
+    {
+        new("Usage", [
+            new("Colors"),
+            new("Sizes"),
+            new("Radius"),
+            new("Shadows"),
+            new("Placements"),
+            new("Offset"),
+            new("Arrow"),
+            new("Custom Content"),
+            new("Two-way Data Binding"),
+        ]),
+        new("Custom Styles"),
+        new("API")
+    };
+
+    private readonly Slot[] _slots = new Slot[]
+    {
+        new(nameof(TooltipSlots.Base), "The overall container of the tooltip."),
+        new(nameof(TooltipSlots.Content), "The container of the tooltip content."),
+        new(nameof(TooltipSlots.Arrow), "The arrow element that connects the tooltip to its trigger element."),
+    };
+
+    private readonly string[] _apiComponents = new string[]
+    {
+        nameof(LumexTooltip),
+        nameof(LumexButton),
+    };
+
+    protected override void OnInitialized()
+    {
+        Layout.Initialize(
+            title: "Tooltip",
+            category: "Components",
+            description: "Tooltips display a brief, informative message that appears when a user interacts with an element.",
+            headings: _headings,
+            linksProps: new ComponentLinksProps( "Tooltip", isServer: false )
+        );
+    }
+}

--- a/src/LumexUI/Common/Enums/TooltipPlacement.cs
+++ b/src/LumexUI/Common/Enums/TooltipPlacement.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) LumexUI 2024
+// LumexUI licenses this file to you under the MIT license
+// See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
+
+using System.ComponentModel;
+
+namespace LumexUI.Common;
+
+/// <summary>
+/// Specifies the placement options for the <see cref="LumexTooltip"/>.
+/// </summary>
+public enum TooltipPlacement
+{
+	/// <summary>
+	/// Positions the tooltip at the top.
+	/// </summary>
+	[Description( "top" )]
+	Top,
+
+	/// <summary>
+	/// Positions the tooltip at the top, aligned to the start.
+	/// </summary>
+	[Description( "top-start" )]
+	TopStart,
+
+	/// <summary>
+	/// Positions the tooltip at the top, aligned to the end.
+	/// </summary>
+	[Description( "top-end" )]
+	TopEnd,
+
+	/// <summary>
+	/// Positions the tooltip to the right.
+	/// </summary>
+	[Description( "right" )]
+	Right,
+
+	/// <summary>
+	/// Positions the tooltip to the right, aligned to the start.
+	/// </summary>
+	[Description( "right-start" )]
+	RightStart,
+
+	/// <summary>
+	/// Positions the tooltip to the right, aligned to the end.
+	/// </summary>
+	[Description( "right-end" )]
+	RightEnd,
+
+	/// <summary>
+	/// Positions the tooltip at the bottom.
+	/// </summary>
+	[Description( "bottom" )]
+	Bottom,
+
+	/// <summary>
+	/// Positions the tooltip at the bottom, aligned to the start.
+	/// </summary>
+	[Description( "bottom-start" )]
+	BottomStart,
+
+	/// <summary>
+	/// Positions the tooltip at the bottom, aligned to the end.
+	/// </summary>
+	[Description( "bottom-end" )]
+	BottomEnd,
+
+	/// <summary>
+	/// Positions the tooltip to the left.
+	/// </summary>
+	[Description( "left" )]
+	Left,
+
+	/// <summary>
+	/// Positions the tooltip to the left, aligned to the start.
+	/// </summary>
+	[Description( "left-start" )]
+	LeftStart,
+
+	/// <summary>
+	/// Positions the tooltip to the left, aligned to the end.
+	/// </summary>
+	[Description( "left-end" )]
+	LeftEnd
+}
+

--- a/src/LumexUI/Components/Dropdown/LumexDropdownItem.cs
+++ b/src/LumexUI/Components/Dropdown/LumexDropdownItem.cs
@@ -45,7 +45,7 @@ public partial class LumexDropdownItem : MenuItem, ISlotComponent<DropdownItemSl
 			return;
 		}
 
-		await Dropdown.HideAsync();
+		await Dropdown.CloseAsync();
 		await OnClick.InvokeAsync( args );
 
 		Dropdown.Rerender();

--- a/src/LumexUI/Components/Popover/LumexPopover.razor.cs
+++ b/src/LumexUI/Components/Popover/LumexPopover.razor.cs
@@ -89,12 +89,12 @@ public partial class LumexPopover : LumexComponentBase, ISlotComponent<PopoverSl
 	/// <summary>
 	/// Gets or sets a value indicating whether the popover is currently open.
 	/// </summary>
-	[Parameter] public bool Opened { get; set; }
+	[Parameter] public bool Open { get; set; }
 
 	/// <summary>
 	/// Gets or sets a callback that is invoked when the open state of the popover changes.
 	/// </summary>
-	[Parameter] public EventCallback<bool> OpenedChanged { get; set; }
+	[Parameter] public EventCallback<bool> OpenChanged { get; set; }
 
 	/// <summary>
 	/// Gets or sets the CSS class names for the popover slots.
@@ -122,9 +122,20 @@ public partial class LumexPopover : LumexComponentBase, ISlotComponent<PopoverSl
 	/// Asynchronously triggers the popover.
 	/// </summary>
 	/// <returns>A <see cref="Task"/> representing the asynchronous trigger operation.</returns>
-	public Task TriggerAsync()
+	public async Task TriggerAsync()
 	{
-		return _context.TriggerAsync();
+		Open = !Open;
+
+		if( Open )
+		{
+			await OpenAsync();
+		}
+		else
+		{
+			await CloseAsync();
+		}
+
+		StateHasChanged();
 	}
 
 	/// <inheritdoc />
@@ -153,25 +164,16 @@ public partial class LumexPopover : LumexComponentBase, ISlotComponent<PopoverSl
 		} );
 	}
 
-	internal async Task<bool> ShowAsync()
+	internal Task OpenAsync()
 	{
-		if( PopoverService.LastShown == this )
-		{
-			PopoverService.SetLastShown( null );
-			return false;
-		}
-
-		Opened = true;
-		PopoverService.SetLastShown( this );
-		await OpenedChanged.InvokeAsync( Opened );
-		return true;
+		Open = true;
+		return OpenChanged.InvokeAsync( true );
 	}
 
-	internal Task HideAsync()
+	internal Task CloseAsync()
 	{
-		Opened = false;
-		PopoverService.SetLastShown( null );
-		return OpenedChanged.InvokeAsync( Opened );
+		Open = false;
+		return OpenChanged.InvokeAsync( false );
 	}
 
 	/// <inheritdoc />

--- a/src/LumexUI/Components/Popover/LumexPopoverContent.razor
+++ b/src/LumexUI/Components/Popover/LumexPopoverContent.razor
@@ -3,13 +3,13 @@
 
 @if( Popover.Open )
 {
-    <PopoverWrapper>
-        <Motion Enter="@(new { Opacity = new float[] { 0, 1 } })">
+    <PopoverWrapper Class="@Popover.Slots["Wrapper"]()">
+        @* <Motion Enter="@_motionProps.Enter"> *@
             <div role="dialog"
-                    class="@Popover.Slots["Base"]( Popover.Classes?.Base, Popover.Class )"
-                    tabindex="-1"
-                    data-slot="base"
-                    @attributes="@Popover.AdditionalAttributes">
+                 class="@Popover.Slots["Base"]( Popover.Classes?.Base, Popover.Class )"
+                 tabindex="-1"
+                 data-slot="base"
+                 @attributes="@Popover.AdditionalAttributes">
                 <LumexComponent As="@As"
                                 Class="@Popover.Slots["Content"](Popover.Classes?.Content, Class)"
                                 Style="@RootStyle"
@@ -21,9 +21,9 @@
                 @if( Popover.ShowArrow )
                 {
                     <span class="@Popover.Slots["Arrow"]( Popover.Classes?.Arrow )"
-                            data-slot="arrow" />
+                          data-slot="arrow" />
                 }
             </div>
-        </Motion>
+        @* </Motion> *@
     </PopoverWrapper>
 }

--- a/src/LumexUI/Components/Popover/LumexPopoverContent.razor
+++ b/src/LumexUI/Components/Popover/LumexPopoverContent.razor
@@ -1,29 +1,29 @@
 ﻿@namespace LumexUI
 @inherits LumexComponentBase
 
-@if (Popover.Opened)
+@if( Popover.Open )
 {
-    <div class="@Popover.Slots["Wrapper"]()"
-         style="position: absolute; z-index: 10000;"
-         data-popover="@Popover.Id"
-         @onclickoutside="@(async() => await ClickOutsideAsync())">
-        <div role="dialog"
-             class="@Popover.Slots["Base"](Popover.Classes?.Base, Popover.Class)"
-             tabindex="-1"
-             data-slot="base"
-             @attributes="@Popover.AdditionalAttributes">
-            <LumexComponent As="@As"
-                            Class="@Popover.Slots["Content"](Popover.Classes?.Content, Class)"
-                            Style="@RootStyle"
-                            data-slot="content"
-                            @attributes="@AdditionalAttributes">
-                @ChildContent
-            </LumexComponent>
-            @if (Popover.ShowArrow)
-            {
-                <span class="@Popover.Slots["Arrow"](Popover.Classes?.Arrow)"
-                      data-slot="arrow" />
-            }
-        </div>
-    </div>
+    <PopoverWrapper>
+        <Motion Enter="@(new { Opacity = new float[] { 0, 1 } })">
+            <div role="dialog"
+                    class="@Popover.Slots["Base"]( Popover.Classes?.Base, Popover.Class )"
+                    tabindex="-1"
+                    data-slot="base"
+                    @attributes="@Popover.AdditionalAttributes">
+                <LumexComponent As="@As"
+                                Class="@Popover.Slots["Content"](Popover.Classes?.Content, Class)"
+                                Style="@RootStyle"
+                                data-slot="content"
+                                @attributes="@AdditionalAttributes">
+                    @ChildContent
+                </LumexComponent>
+
+                @if( Popover.ShowArrow )
+                {
+                    <span class="@Popover.Slots["Arrow"]( Popover.Classes?.Arrow )"
+                            data-slot="arrow" />
+                }
+            </div>
+        </Motion>
+    </PopoverWrapper>
 }

--- a/src/LumexUI/Components/Popover/LumexPopoverContent.razor
+++ b/src/LumexUI/Components/Popover/LumexPopoverContent.razor
@@ -5,25 +5,26 @@
 {
     <PopoverWrapper Class="@Popover.Slots["Wrapper"]()">
         @* <Motion Enter="@_motionProps.Enter"> *@
-            <div role="dialog"
-                 class="@Popover.Slots["Base"]( Popover.Classes?.Base, Popover.Class )"
-                 tabindex="-1"
-                 data-slot="base"
-                 @attributes="@Popover.AdditionalAttributes">
-                <LumexComponent As="@As"
-                                Class="@Popover.Slots["Content"](Popover.Classes?.Content, Class)"
-                                Style="@RootStyle"
-                                data-slot="content"
-                                @attributes="@AdditionalAttributes">
-                    @ChildContent
-                </LumexComponent>
+        <div role="dialog"
+             class="@Popover.Slots["Base"]( Popover.Classes?.Base, Popover.Class )"
+             tabindex="-1"
+             data-slot="base"
+             data-open="@Popover.Open.ToAttributeValue()"
+             @attributes="@Popover.AdditionalAttributes">
+            <LumexComponent As="@As"
+                            Class="@Popover.Slots["Content"](Popover.Classes?.Content, Class)"
+                            Style="@RootStyle"
+                            data-slot="content"
+                            @attributes="@AdditionalAttributes">
+                @ChildContent
+            </LumexComponent>
 
-                @if( Popover.ShowArrow )
-                {
-                    <span class="@Popover.Slots["Arrow"]( Popover.Classes?.Arrow )"
-                          data-slot="arrow" />
-                }
-            </div>
+            @if( Popover.ShowArrow )
+            {
+                <span class="@Popover.Slots["Arrow"]( Popover.Classes?.Arrow )"
+                      data-slot="arrow" />
+            }
+        </div>
         @* </Motion> *@
     </PopoverWrapper>
 }

--- a/src/LumexUI/Components/Popover/LumexPopoverContent.razor.cs
+++ b/src/LumexUI/Components/Popover/LumexPopoverContent.razor.cs
@@ -2,12 +2,9 @@
 // LumexUI licenses this file to you under the MIT license
 // See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
 
-using System.Diagnostics.CodeAnalysis;
-
 using LumexUI.Common;
 
 using Microsoft.AspNetCore.Components;
-using Microsoft.JSInterop;
 
 namespace LumexUI;
 
@@ -15,10 +12,8 @@ namespace LumexUI;
 /// A component representing the content of the <see cref="LumexPopover"/>.
 /// </summary>
 [CompositionComponent( typeof( LumexPopover ) )]
-public partial class LumexPopoverContent : LumexComponentBase, IAsyncDisposable
+public partial class LumexPopoverContent : LumexComponentBase
 {
-	private const string JavaScriptFile = "./_content/LumexUI/js/components/popover.bundle.js";
-
 	/// <summary>
 	/// Gets or sets content to be rendered as the popover content.
 	/// </summary>
@@ -26,64 +21,11 @@ public partial class LumexPopoverContent : LumexComponentBase, IAsyncDisposable
 
 	[CascadingParameter] internal PopoverContext Context { get; set; } = default!;
 
-	[Inject] private IJSRuntime JSRuntime { get; set; } = default!;
-
 	private LumexPopover Popover => Context.Owner;
-
-	private IJSObjectReference _jsModule = default!;
 
 	/// <inheritdoc />
 	protected override void OnInitialized()
 	{
 		ContextNullException.ThrowIfNull( Context, nameof( LumexPopoverContent ) );
-
-		Context.OnTrigger += ShowAsync;
-	}
-
-	/// <inheritdoc />
-	protected override async Task OnAfterRenderAsync( bool firstRender )
-	{
-		if( firstRender )
-		{
-			_jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>( "import", JavaScriptFile );
-		}
-	}
-
-	private ValueTask ShowAsync()
-	{
-		// We need to render a popover first.
-		StateHasChanged();
-
-		// Then we initialize the popover on the JS side by:
-		//  1. Adding a 'clickoutside' event handler
-		//  2. Applying a proper positioning
-		return _jsModule.InvokeVoidAsync( "popover.initialize", Context.Owner.Id, Context.Owner.Options );
-	}
-
-	private async ValueTask ClickOutsideAsync()
-	{
-		await Context.Owner.HideAsync();
-		await _jsModule.InvokeVoidAsync( "popover.destroy" );
-	}
-
-	/// <inheritdoc />
-	[ExcludeFromCodeCoverage]
-	public async ValueTask DisposeAsync()
-	{
-		try
-		{
-			if( _jsModule is not null )
-			{
-				await _jsModule.InvokeVoidAsync( "popover.destroy" );
-				await _jsModule.DisposeAsync();
-			}
-
-			Context.OnTrigger -= ShowAsync;
-		}
-		catch( Exception ex ) when( ex is JSDisconnectedException or OperationCanceledException )
-		{
-			// The JSRuntime side may routinely be gone already if the reason we're disposing is that
-			// the client disconnected. This is not an error.
-		}
 	}
 }

--- a/src/LumexUI/Components/Popover/LumexPopoverContent.razor.cs
+++ b/src/LumexUI/Components/Popover/LumexPopoverContent.razor.cs
@@ -3,6 +3,7 @@
 // See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
 
 using LumexUI.Common;
+using LumexUI.Motion.Types;
 
 using Microsoft.AspNetCore.Components;
 
@@ -22,6 +23,22 @@ public partial class LumexPopoverContent : LumexComponentBase
 	[CascadingParameter] internal PopoverContext Context { get; set; } = default!;
 
 	private LumexPopover Popover => Context.Owner;
+
+	private readonly MotionProps _motionProps; 
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public LumexPopoverContent()
+	{
+		_motionProps = new MotionProps
+		{
+			Enter = new
+			{
+				Opacity = new float[] { 0, 1 } // Animate opacity from 0 to 1.
+			}
+		};
+	}
 
 	/// <inheritdoc />
 	protected override void OnInitialized()

--- a/src/LumexUI/Components/Popover/LumexPopoverTrigger.razor.cs
+++ b/src/LumexUI/Components/Popover/LumexPopoverTrigger.razor.cs
@@ -62,7 +62,7 @@ public partial class LumexPopoverTrigger : LumexButton
 			return;
 		}
 
-		await Context.TriggerAsync();
+		//await Context.ToggleAsync();
 		await OnClick.InvokeAsync( args );
 	}
 

--- a/src/LumexUI/Components/Popover/PopoverContext.cs
+++ b/src/LumexUI/Components/Popover/PopoverContext.cs
@@ -4,17 +4,5 @@ namespace LumexUI;
 
 internal class PopoverContext( LumexPopover owner ) : IComponentContext<LumexPopover>
 {
-    public LumexPopover Owner { get; } = owner;
-
-    public event Func<ValueTask> OnTrigger = default!;
-
-    public async Task TriggerAsync()
-    {
-        if( await Owner.ShowAsync() )
-        {
-            await NotifyStateChangedAsync();
-        }
-    }
-
-    private ValueTask NotifyStateChangedAsync() => OnTrigger.Invoke();
+	public LumexPopover Owner { get; } = owner;
 }

--- a/src/LumexUI/Components/Popover/PopoverWrapper.cs
+++ b/src/LumexUI/Components/Popover/PopoverWrapper.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) LumexUI 2024
+// LumexUI licenses this file to you under the MIT license
+// See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
+
+using System.Diagnostics.CodeAnalysis;
+
+using LumexUI.Utilities;
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.JSInterop;
+
+namespace LumexUI.Internal;
+
+/// <summary>
+/// 
+/// </summary>
+public class PopoverWrapper : LumexComponentBase, IAsyncDisposable
+{
+	private const string JavaScriptFile = "./_content/LumexUI/js/components/popover.bundle.js";
+
+	/// <summary>
+	/// Gets or sets content to be rendered inside the popover wrapper.
+	/// </summary>
+	[Parameter] public RenderFragment? ChildContent { get; set; }
+
+	[CascadingParameter] internal PopoverContext Context { get; set; } = default!;
+
+	[Inject] private IJSRuntime JSRuntime { get; set; } = default!;
+
+	private readonly string? _style = new ElementStyle()
+		.Add( "position", "absolute" )
+		.Add( "z-index", "10000" )
+		.ToString();
+
+	private LumexPopover Popover => Context.Owner;
+
+	private IJSObjectReference _jsModule = default!;
+
+	/// <inheritdoc />
+	protected override async Task OnAfterRenderAsync( bool firstRender )
+	{
+		if( firstRender )
+		{
+			_jsModule = await JSRuntime.InvokeAsync<IJSObjectReference>( "import", JavaScriptFile );
+			await _jsModule.InvokeVoidAsync( "popover.initialize", Context.Owner.Id, Context.Owner.Options );
+		}
+	}
+
+	/// <inheritdoc />
+	protected override void BuildRenderTree( RenderTreeBuilder builder )
+	{
+		builder.OpenElement( 0, As );
+		builder.AddAttribute( 1, "style", _style );
+		builder.AddAttribute( 2, "data-popover", Popover.Id );
+		builder.AddAttribute( 3, "onclickoutside", EventCallback.Factory.Create<EventArgs>( this, async e => await CloseAsync() ) );
+		builder.AddMultipleAttributes( 4, AdditionalAttributes );
+		builder.AddContent( 5, ChildContent );
+		builder.CloseElement();
+	}
+
+	private async ValueTask CloseAsync()
+	{
+		await Popover.CloseAsync();
+		await _jsModule.InvokeVoidAsync( "popover.destroy" );
+
+		Popover.Rerender();
+	}
+
+	/// <inheritdoc />
+	[ExcludeFromCodeCoverage]
+	async ValueTask IAsyncDisposable.DisposeAsync()
+	{
+		try
+		{
+			if( _jsModule is not null )
+			{
+				await CloseAsync();
+				await _jsModule.DisposeAsync();
+			}
+		}
+		catch( Exception ex ) when( ex is JSDisconnectedException or OperationCanceledException )
+		{
+			// The JSRuntime side may routinely be gone already if the reason we're disposing is that
+			// the client disconnected. This is not an error.
+		}
+	}
+}

--- a/src/LumexUI/Components/Select/LumexSelect.razor
+++ b/src/LumexUI/Components/Select/LumexSelect.razor
@@ -35,7 +35,7 @@
                                 type="button"
                                 data-slot="trigger"
                                 data-popoverref="@_popoverRef?.Id"
-                                data-open="@Utils.GetDataAttributeValue( _isOpened )"
+                                data-open="@Utils.GetDataAttributeValue( _isOpen )"
                                 @onclick="@TriggerAsync"
                                 @onfocus="@OnFocusAsync"
                                 @onblur="@OnBlurAsync">
@@ -48,7 +48,7 @@
                     <LumexIcon Icon="@Icons.Rounded.KeyboardArrowDown"
                                Class="@_slots.SelectorIcon"
                                data-slot="selector-icon"
-                               data-open="@Utils.GetDataAttributeValue( _isOpened )">
+                               data-open="@Utils.GetDataAttributeValue( _isOpen )">
                     </LumexIcon>
                 </LumexComponent>
                 @_renderHelperWrapper
@@ -95,7 +95,7 @@
                       Classes="@_popoverSlots"
                       data-slot="popover"
                       @ref="@_popoverRef"
-                      @bind-Opened="@_isOpened">
+                      @bind-Open="@_isOpen">
             <LumexPopoverContent>
                 @if (_context.IsMultiSelect)
                 {

--- a/src/LumexUI/Components/Select/LumexSelect.razor.cs
+++ b/src/LumexUI/Components/Select/LumexSelect.razor.cs
@@ -147,7 +147,7 @@ public partial class LumexSelect<TValue> : LumexInputBase<TValue>, ISlotComponen
         !string.IsNullOrEmpty( ErrorMessage );
 
     private bool Filled =>
-        _isOpened ||
+        _isOpen ||
         HasValue ||
         StartContent is not null ||
         EndContent is not null ||
@@ -167,7 +167,7 @@ public partial class LumexSelect<TValue> : LumexInputBase<TValue>, ISlotComponen
     private ListboxSlots _listboxSlots = default!;
     private LumexPopover? _popoverRef;
 
-    private bool _isOpened;
+    private bool _isOpen;
     private bool _hasInitializedParameters;
 
     /// <summary>
@@ -272,7 +272,7 @@ public partial class LumexSelect<TValue> : LumexInputBase<TValue>, ISlotComponen
         Debug.Assert( _popoverRef is not null );
 
         await SetCurrentValueAsync( value );
-        await _popoverRef.HideAsync();
+        await _popoverRef.CloseAsync();
         _context.UpdateSelectedItem( CurrentValue );
     }
 

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor
@@ -7,7 +7,14 @@
     @ChildContent
 
     <LumexPopover Id="@_popoverId"
-                  Open="@_isOpen"
+                  Open="@Open"
+                  Size="@Size"
+                  Color="@Color"
+                  Radius="@Radius"
+                  Shadow="@Shadow"
+                  Offset="@Offset"
+                  ShowArrow="@ShowArrow"
+                  Placement="@GetPlacement()"
                   Class="@Class"
                   Style="@Style"
                   @attributes="@AdditionalAttributes">

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor
@@ -1,4 +1,25 @@
 ﻿@namespace LumexUI
 @inherits LumexComponentBase
 
+<div data-popoverref="@_popoverId"
+     @onpointerenter="@OnPointerEnterAsync"
+     @onpointerleave="@OnPointerLeaveAsync">
+    @ChildContent
 
+    <LumexPopover Id="@_popoverId"
+                  Open="@_isOpen"
+                  Class="@Class"
+                  Style="@Style"
+                  @attributes="@AdditionalAttributes">
+        <LumexPopoverContent>
+            @if( Content is RenderFragment renderFragment )
+            {
+                @renderFragment
+            }
+            else
+            {
+                @Content
+            }
+        </LumexPopoverContent>
+    </LumexPopover>
+</div>

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor
@@ -2,8 +2,10 @@
 @inherits LumexComponentBase
 
 <div data-popoverref="@_popoverId"
-     @onpointerenter="@OnPointerEnterAsync"
-     @onpointerleave="@OnPointerLeaveAsync">
+     @onmouseenter="@OnMouseEnterAsync"
+     @onmouseleave="@OnMouseLeaveAsync"
+     @onfocusin="@OnFocusInAsync" 
+     @onfocusout="@OnFocusOutAsync">
     @ChildContent
 
     <LumexPopover Id="@_popoverId"
@@ -17,6 +19,7 @@
                   Placement="@GetPlacement()"
                   Class="@Class"
                   Style="@Style"
+                  role="tooltip"
                   @attributes="@AdditionalAttributes">
         <LumexPopoverContent>
             @if( Content is RenderFragment renderFragment )

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor
@@ -7,30 +7,30 @@
      @onfocusin="@OnFocusInAsync" 
      @onfocusout="@OnFocusOutAsync">
     @ChildContent
-
-    <LumexPopover Id="@_popoverId"
-                  Open="@Open"
-                  Size="@Size"
-                  Color="@Color"
-                  Radius="@Radius"
-                  Shadow="@Shadow"
-                  Offset="@Offset"
-                  ShowArrow="@ShowArrow"
-                  Placement="@GetPlacement()"
-                  Class="@Class"
-                  Classes="@Classes"
-                  Style="@Style"
-                  role="tooltip"
-                  @attributes="@AdditionalAttributes">
-        <LumexPopoverContent>
-            @if( Content is RenderFragment renderFragment )
-            {
-                @renderFragment
-            }
-            else
-            {
-                @Content
-            }
-        </LumexPopoverContent>
-    </LumexPopover>
 </div>
+
+<LumexPopover Id="@_popoverId"
+              Open="@Open"
+              Size="@Size"
+              Color="@Color"
+              Radius="@Radius"
+              Shadow="@Shadow"
+              Offset="@Offset"
+              ShowArrow="@ShowArrow"
+              Placement="@GetPlacement()"
+              Class="@Class"
+              Classes="@Classes"
+              Style="@Style"
+              role="tooltip"
+              @attributes="@AdditionalAttributes">
+    <LumexPopoverContent>
+        @if( Content is RenderFragment renderFragment )
+        {
+            @renderFragment
+        }
+        else
+        {
+            @Content
+        }
+    </LumexPopoverContent>
+</LumexPopover>

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor
@@ -18,6 +18,7 @@
                   ShowArrow="@ShowArrow"
                   Placement="@GetPlacement()"
                   Class="@Class"
+                  Classes="@Classes"
                   Style="@Style"
                   role="tooltip"
                   @attributes="@AdditionalAttributes">

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor
@@ -1,0 +1,4 @@
+﻿@namespace LumexUI
+@inherits LumexComponentBase
+
+

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor
@@ -1,13 +1,13 @@
 ﻿@namespace LumexUI
 @inherits LumexComponentBase
 
-<div data-popoverref="@_popoverId"
-     @onmouseenter="@OnMouseEnterAsync"
-     @onmouseleave="@OnMouseLeaveAsync"
-     @onfocusin="@OnFocusInAsync" 
-     @onfocusout="@OnFocusOutAsync">
+<span data-popoverref="@_popoverId"
+      @onmouseenter="@OnMouseEnterAsync"
+      @onmouseleave="@OnMouseLeaveAsync"
+      @onfocusin="@OnFocusInAsync"
+      @onfocusout="@OnFocusOutAsync">
     @ChildContent
-</div>
+</span>
 
 <LumexPopover Id="@_popoverId"
               Open="@Open"

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor.cs
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor.cs
@@ -25,14 +25,104 @@ public partial class LumexTooltip : LumexComponentBase, ISlotComponent<TooltipSl
 	[Parameter] public object? Content { get; set; }
 
 	/// <summary>
+	/// Gets or sets a color of the tooltip.
+	/// </summary>
+	/// <remarks>
+	/// The default value is <see cref="ThemeColor.Default"/>
+	/// </remarks>
+	[Parameter] public ThemeColor Color { get; set; } = ThemeColor.Default;
+
+	/// <summary>
+	/// Gets or sets a size of the tooltip content text.
+	/// </summary>
+	/// <remarks>
+	/// The default value is <see cref="Size.Medium"/>
+	/// </remarks>
+	[Parameter] public Size Size { get; set; } = Size.Medium;
+
+	/// <summary>
+	/// Gets or sets a border radius of the tooltip.
+	/// </summary>
+	/// <remarks>
+	/// The default value is <see cref="Radius.Medium"/>
+	/// </remarks>
+	[Parameter] public Radius Radius { get; set; } = Radius.Medium;
+
+	/// <summary>
+	/// Gets or sets a shadow of the tooltip.
+	/// </summary>
+	/// <remarks>
+	/// The default value is <see cref="Shadow.Small"/>
+	/// </remarks>
+	[Parameter] public Shadow Shadow { get; set; } = Shadow.Small;
+
+	/// <summary>
+	/// Gets or sets a placement of the tooltip relative to a reference.
+	/// </summary>
+	/// <remarks>
+	/// The default value is <see cref="TooltipPlacement.Top"/>
+	/// </remarks>
+	[Parameter] public TooltipPlacement Placement { get; set; }
+
+	/// <summary>
+	/// Gets or sets the offset distance between the tooltip and the reference, in pixels.
+	/// </summary>
+	/// <remarks>
+	/// The default value is 8
+	/// </remarks>
+	[Parameter] public int Offset { get; set; } = 8;
+
+	/// <summary>
+	/// Gets or sets a value indicating whether the tooltip should display an arrow pointing to the reference.
+	/// </summary>
+	[Parameter] public bool ShowArrow { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether the tooltip is currently open.
+	/// </summary>
+	[Parameter] public bool Open { get; set; }
+
+	/// <summary>
+	/// Gets or sets a callback that is invoked when the open state of the tooltip changes.
+	/// </summary>
+	[Parameter] public EventCallback<bool> OpenChanged { get; set; }
+
+	/// <summary>
 	/// Gets or sets the CSS class names for the tooltip slots.
 	/// </summary>
 	[Parameter] public TooltipSlots? Classes { get; set; }
 
 	private readonly string _popoverId = Identifier.New();
 
-	private bool _isOpen;
+	private Task OnPointerEnterAsync()
+	{
+		Open = true;
+		return OpenChanged.InvokeAsync( true );
+	}
 
-	private void OnPointerEnterAsync() => _isOpen = true;
-	private void OnPointerLeaveAsync() => _isOpen = false;
+	private Task OnPointerLeaveAsync()
+	{
+		Open = false;
+		return OpenChanged.InvokeAsync( false );
+	}
+
+	private PopoverPlacement GetPlacement()
+	{
+		return Placement switch
+		{
+			TooltipPlacement.Top => PopoverPlacement.Top,
+			TooltipPlacement.TopStart => PopoverPlacement.TopStart,
+			TooltipPlacement.TopEnd => PopoverPlacement.TopEnd,
+			TooltipPlacement.Right => PopoverPlacement.Right,
+			TooltipPlacement.RightStart => PopoverPlacement.RightStart,
+			TooltipPlacement.RightEnd => PopoverPlacement.RightEnd,
+			TooltipPlacement.Bottom => PopoverPlacement.Bottom,
+			TooltipPlacement.BottomStart => PopoverPlacement.BottomStart,
+			TooltipPlacement.BottomEnd => PopoverPlacement.BottomEnd,
+			TooltipPlacement.Left => PopoverPlacement.Left,
+			TooltipPlacement.LeftStart => PopoverPlacement.LeftStart,
+			TooltipPlacement.LeftEnd => PopoverPlacement.LeftEnd,
+			_ => throw new NotImplementedException()
+		};
+	}
 }

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor.cs
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor.cs
@@ -2,6 +2,8 @@
 // LumexUI licenses this file to you under the MIT license
 // See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
 
+using System.Diagnostics.CodeAnalysis;
+
 using LumexUI.Common;
 using LumexUI.Utilities;
 
@@ -17,7 +19,7 @@ public partial class LumexTooltip : LumexComponentBase, ISlotComponent<TooltipSl
 	/// <summary>
 	/// Gets or sets the content around which the tooltip is rendered.
 	/// </summary>
-	[Parameter] public RenderFragment? ChildContent { get; set; }
+	[Parameter, EditorRequired] public RenderFragment ChildContent { get; set; } = default!;
 
 	/// <summary>
 	/// Gets or sets the content to display within the tooltip.
@@ -94,6 +96,12 @@ public partial class LumexTooltip : LumexComponentBase, ISlotComponent<TooltipSl
 
 	private readonly string _popoverId = Identifier.New();
 
+	/// <inheritdoc />
+	protected override void OnParametersSet()
+	{
+		ArgumentNullException.ThrowIfNull( ChildContent );
+	}
+
 	private Task OnMouseEnterAsync() => OpenAsync();
 	private Task OnMouseLeaveAsync() => CloseAsync();
 	private Task OnFocusInAsync() => OpenAsync();
@@ -115,6 +123,7 @@ public partial class LumexTooltip : LumexComponentBase, ISlotComponent<TooltipSl
 		return OpenChanged.InvokeAsync( value );
 	}
 
+	[ExcludeFromCodeCoverage]
 	private PopoverPlacement GetPlacement()
 	{
 		return Placement switch

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor.cs
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor.cs
@@ -94,16 +94,25 @@ public partial class LumexTooltip : LumexComponentBase, ISlotComponent<TooltipSl
 
 	private readonly string _popoverId = Identifier.New();
 
-	private Task OnPointerEnterAsync()
+	private Task OnMouseEnterAsync() => OpenAsync();
+	private Task OnMouseLeaveAsync() => CloseAsync();
+	private Task OnFocusInAsync() => OpenAsync();
+	private Task OnFocusOutAsync() => CloseAsync();
+
+	private Task OpenAsync()
 	{
-		Open = true;
-		return OpenChanged.InvokeAsync( true );
+		return SetOpenAsync( true );
 	}
 
-	private Task OnPointerLeaveAsync()
+	private Task CloseAsync()
 	{
-		Open = false;
-		return OpenChanged.InvokeAsync( false );
+		return SetOpenAsync( false );
+	}
+
+	private Task SetOpenAsync( bool value )
+	{
+		Open = value;
+		return OpenChanged.InvokeAsync( value );
 	}
 
 	private PopoverPlacement GetPlacement()

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor.cs
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor.cs
@@ -1,0 +1,20 @@
+// Copyright (c) LumexUI 2024
+// LumexUI licenses this file to you under the MIT license
+// See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
+
+using LumexUI.Common;
+
+using Microsoft.AspNetCore.Components;
+
+namespace LumexUI;
+
+/// <summary>
+/// A component that represents a tooltip for displaying additional information.
+/// </summary>
+public partial class LumexTooltip : LumexComponentBase, ISlotComponent<TooltipSlots>
+{
+	/// <summary>
+	/// Gets or sets the CSS class names for the tooltip slots.
+	/// </summary>
+	[Parameter] public TooltipSlots? Classes { get; set; }
+}

--- a/src/LumexUI/Components/Tooltip/LumexTooltip.razor.cs
+++ b/src/LumexUI/Components/Tooltip/LumexTooltip.razor.cs
@@ -3,6 +3,7 @@
 // See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
 
 using LumexUI.Common;
+using LumexUI.Utilities;
 
 using Microsoft.AspNetCore.Components;
 
@@ -14,7 +15,24 @@ namespace LumexUI;
 public partial class LumexTooltip : LumexComponentBase, ISlotComponent<TooltipSlots>
 {
 	/// <summary>
+	/// Gets or sets the content around which the tooltip is rendered.
+	/// </summary>
+	[Parameter] public RenderFragment? ChildContent { get; set; }
+
+	/// <summary>
+	/// Gets or sets the content to display within the tooltip.
+	/// </summary>
+	[Parameter] public object? Content { get; set; }
+
+	/// <summary>
 	/// Gets or sets the CSS class names for the tooltip slots.
 	/// </summary>
 	[Parameter] public TooltipSlots? Classes { get; set; }
+
+	private readonly string _popoverId = Identifier.New();
+
+	private bool _isOpen;
+
+	private void OnPointerEnterAsync() => _isOpen = true;
+	private void OnPointerLeaveAsync() => _isOpen = false;
 }

--- a/src/LumexUI/Components/Tooltip/TooltipSlots.cs
+++ b/src/LumexUI/Components/Tooltip/TooltipSlots.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) LumexUI 2024
+// LumexUI licenses this file to you under the MIT license
+// See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
+
+using System.Diagnostics.CodeAnalysis;
+
+using LumexUI.Common;
+
+namespace LumexUI;
+
+/// <summary>
+/// Represents the slot names for the <see cref="LumexTooltip"/>, 
+/// used to assign CSS classes to different parts of the component.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class TooltipSlots : ISlot
+{
+	/// <summary>
+	/// Gets or sets the CSS class for the root slot.
+	/// </summary>
+	[Obsolete( "Deprecated. This will be removed in the future releases. Use the 'Base' slot instead." )]
+	public string? Root { get; set; }
+
+	/// <summary>
+	/// Gets or sets the CSS class for the base slot.
+	/// </summary>
+	public string? Base { get; set; }
+
+	/// <summary>
+	/// Gets or sets the CSS class for the arrow slot.
+	/// </summary>
+	public string? Arrow { get; set; }
+}

--- a/src/LumexUI/Components/Tooltip/TooltipSlots.cs
+++ b/src/LumexUI/Components/Tooltip/TooltipSlots.cs
@@ -13,21 +13,6 @@ namespace LumexUI;
 /// used to assign CSS classes to different parts of the component.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class TooltipSlots : ISlot
+public class TooltipSlots : PopoverSlots, ISlot
 {
-	/// <summary>
-	/// Gets or sets the CSS class for the root slot.
-	/// </summary>
-	[Obsolete( "Deprecated. This will be removed in the future releases. Use the 'Base' slot instead." )]
-	public string? Root { get; set; }
-
-	/// <summary>
-	/// Gets or sets the CSS class for the base slot.
-	/// </summary>
-	public string? Base { get; set; }
-
-	/// <summary>
-	/// Gets or sets the CSS class for the arrow slot.
-	/// </summary>
-	public string? Arrow { get; set; }
 }

--- a/src/LumexUI/Services/Popover/IPopoverService.cs
+++ b/src/LumexUI/Services/Popover/IPopoverService.cs
@@ -10,11 +10,6 @@ namespace LumexUI.Services;
 public interface IPopoverService
 {
 	/// <summary>
-	/// Gets the last shown popover.
-	/// </summary>
-	LumexPopover? LastShown { get; }
-
-	/// <summary>
 	/// Registers a popover with the service.
 	/// </summary>
 	/// <param name="popover">The popover to register.</param>
@@ -25,12 +20,6 @@ public interface IPopoverService
 	/// </summary>
 	/// <param name="popover">The popover to unregister.</param>
 	void Unregister( LumexPopover popover );
-
-	/// <summary>
-	/// Sets the last shown popover.
-	/// </summary>
-	/// <param name="popover">The popover to set as the last shown instance.</param>
-	void SetLastShown( LumexPopover? popover );
 
 	/// <summary>
 	/// 

--- a/src/LumexUI/Services/Popover/PopoverService.cs
+++ b/src/LumexUI/Services/Popover/PopoverService.cs
@@ -15,12 +15,6 @@ public class PopoverService : IPopoverService
 	public LumexPopover? LastShown { get; private set; }
 
 	/// <inheritdoc />
-	public void SetLastShown( LumexPopover? popover )
-	{
-		LastShown = popover;
-	}
-
-	/// <inheritdoc />
 	public void Register( LumexPopover popover )
 	{
 		if( !string.IsNullOrEmpty( popover.Id ) )

--- a/src/LumexUI/Styles/Popover.cs
+++ b/src/LumexUI/Styles/Popover.cs
@@ -133,6 +133,10 @@ internal static class Popover
 					[nameof( Radius.Large )] = new SlotCollection()
 					{
 						[nameof( PopoverSlots.Content )] = "rounded-large"
+					},
+					[nameof( Radius.Full )] = new SlotCollection()
+					{
+						[nameof( PopoverSlots.Content )] = "rounded-full"
 					}
 				},
 

--- a/src/LumexUI/Styles/Popover.cs
+++ b/src/LumexUI/Styles/Popover.cs
@@ -30,6 +30,10 @@ internal static class Popover
 					.Add( "bg-transparent" )
 					.ToString(),
 
+				["Wrapper"] = new ElementClass()
+					.Add( "animate-enter" )
+					.ToString(),
+
 				[nameof( PopoverSlots.Content )] = new ElementClass()
 					.Add( "z-10" )
 					.Add( "py-1" )

--- a/src/LumexUI/Styles/Popover.cs
+++ b/src/LumexUI/Styles/Popover.cs
@@ -30,10 +30,6 @@ internal static class Popover
 					.Add( "bg-transparent" )
 					.ToString(),
 
-				["Wrapper"] = new ElementClass()
-					.Add( "animate-enter" )
-					.ToString(),
-
 				[nameof( PopoverSlots.Content )] = new ElementClass()
 					.Add( "z-10" )
 					.Add( "py-1" )

--- a/src/LumexUI/wwwroot/js/components/popover.js
+++ b/src/LumexUI/wwwroot/js/components/popover.js
@@ -26,19 +26,19 @@ async function initialize(id, options) {
         const arrowElement = popover.querySelector('[data-slot=arrow]');
 
         portalTo(popover);
-        destroyOutsideClickHandler = createOutsideClickHandler(popover);
+        destroyOutsideClickHandler = createOutsideClickHandler([ref, popover]);
 
         const {
+            offset: offsetVal,
             placement,
             showArrow,
-            offset: offsetVal,
-            matchRefWidth
+            matchRefWidth,
         } = options;
 
         const middlewares = [
+            offset(offsetVal),
             flip(),
             shift(),
-            offset(offsetVal)
         ];
 
         if (showArrow) {
@@ -59,7 +59,7 @@ async function initialize(id, options) {
 
         const data = await computePosition(ref, popover, {
             placement: placement,
-            middleware: middlewares
+            middleware: middlewares,
         });
 
         positionPopover(popover, data);
@@ -68,11 +68,11 @@ async function initialize(id, options) {
             positionArrow(arrowElement, data);
         }
     } catch (error) {
-        console.error('Error in popover.show:', error);
+        console.error('Error in popover.initialize:', error);
     }
 
-    function positionPopover(target, data) {
-        Object.assign(target.style, {
+    function positionPopover(popover, data) {
+        Object.assign(popover.style, {
             left: `${data.x}px`,
             top: `${data.y}px`,
         });

--- a/src/LumexUI/wwwroot/js/components/popover.js
+++ b/src/LumexUI/wwwroot/js/components/popover.js
@@ -65,7 +65,7 @@ async function initialize(id, options) {
         positionPopover(popover, data);
 
         if (showArrow) {
-            positionArrow(arrowElement, placement, data);
+            positionArrow(arrowElement, data);
         }
     } catch (error) {
         console.error('Error in popover.show:', error);
@@ -78,8 +78,10 @@ async function initialize(id, options) {
         });
     }
 
-    function positionArrow(target, placement, data) {
-        const { x: arrowX, y: arrowY } = data.middlewareData.arrow;
+    function positionArrow(arrow, data) {
+        const { placement, middlewareData } = data;
+        const { x: arrowX, y: arrowY } = middlewareData.arrow;
+
         const staticSide = {
             top: 'bottom',
             right: 'left',
@@ -87,9 +89,11 @@ async function initialize(id, options) {
             left: 'right',
         }[placement.split('-')[0]];
 
-        Object.assign(target.style, {
+        Object.assign(arrow.style, {
             left: arrowX != null ? `${arrowX}px` : '',
             top: arrowY != null ? `${arrowY}px` : '',
+            right: '',
+            bottom: '',
             [staticSide]: '-4px',
         });
     }

--- a/src/LumexUI/wwwroot/js/utils/dom.js
+++ b/src/LumexUI/wwwroot/js/utils/dom.js
@@ -40,10 +40,14 @@ export function portalTo(element, selector = undefined) {
     }
 }
 
-export function createOutsideClickHandler(element) {
+export function createOutsideClickHandler(elements) {
     const clickHandler = event => {
-        if (element && !element.contains(event.target)) {
-            element.dispatchEvent(new CustomEvent('clickoutside', { bubbles: true }));
+        const isInsideAny = elements.some(el => el && el.contains(event.target));
+
+        if (!isInsideAny) {
+            elements.forEach(el =>
+                el?.dispatchEvent(new CustomEvent('clickoutside', { bubbles: true }))
+            );
         }
     };
 

--- a/tests/LumexUI.Tests/Components/Dropdown/DropdownTests.razor
+++ b/tests/LumexUI.Tests/Components/Dropdown/DropdownTests.razor
@@ -45,7 +45,11 @@
                     Trigger
                 </LumexButton>
                 <LumexDropdown Id="@id">
-                    <LumexDropdownMenu></LumexDropdownMenu>
+                    <LumexDropdownMenu>
+                        <EmptyContent>
+                            <span>No items \(o_o)/</span>
+                        </EmptyContent>
+                    </LumexDropdownMenu>
                 </LumexDropdown>
             </text>
         );

--- a/tests/LumexUI.Tests/Components/Popover/PopoverTests.razor
+++ b/tests/LumexUI.Tests/Components/Popover/PopoverTests.razor
@@ -21,147 +21,96 @@
     [Fact]
     public void ShouldRenderCorrectly()
     {
-        var action = () => Render<LumexPopover>(
-    @<LumexPopover>
-        <LumexPopoverTrigger>Show Popover</LumexPopoverTrigger>
-        <LumexPopoverContent>
-            <p>This is the content of the popover.</p>
-        </LumexPopoverContent>
-    </LumexPopover>
-    );
+        var id = "1";
+        var action = () => Render(
+            @<text>
+                <LumexButton OnClick="@(() => TriggerAsync( id ))" data-popoverref="@id">
+                    Trigger
+                </LumexButton>
+                <LumexPopover Id="@id">
+                    <LumexPopoverContent>
+                        <p>This is the content of the popover.</p>
+                    </LumexPopoverContent>
+                </LumexPopover>
+            </text>
+        );
 
         action.Should().NotThrow();
     }
 
     [Fact]
-    public void ShouldShowOnTrigger()
+    public void ShouldOpenOnTriggerClick()
     {
-        var cut = Render<LumexPopover>(
-    @<LumexPopover>
-        <LumexPopoverTrigger>Show Popover</LumexPopoverTrigger>
-        <LumexPopoverContent>
-            <p>This is the content of the popover.</p>
-        </LumexPopoverContent>
-    </LumexPopover>
+        var id = "2";
+        var cut = Render(
+            @<text>
+                <LumexButton OnClick="@(() => TriggerAsync( id ))" data-popoverref="@id">
+                    Trigger
+                </LumexButton>
+                <LumexPopover Id="@id">
+                    <LumexPopoverContent>
+                        <p>This is the content of the popover.</p>
+                    </LumexPopoverContent>
+                </LumexPopover>
+            </text>
         );
 
-        var popoverTrigger = cut.FindComponent<LumexPopoverTrigger>();
-        var triggerButton = popoverTrigger.Find( "button" );
+        var trigger = cut.Find( "[data-popoverref]" );
+        trigger.Click();
 
-        cut.Instance.Opened.Should().BeFalse( because: "An initial state" );
-
-        triggerButton.Click();
-
-        cut.Instance.Opened.Should().BeTrue( because: "The trigger is clicked" );
+        var popover = cut.FindBySlot( "base" );
+        popover?.GetAttribute("data-open").Should().Be( "true" );
     }
 
     [Fact]
-    public void ShouldHideOnOutsideClick()
+    public void ShouldCloseOnOutsideClick()
     {
-        var cut = Render<LumexPopover>(
-    @<LumexPopover>
-        <LumexPopoverTrigger>Show Popover</LumexPopoverTrigger>
-        <LumexPopoverContent>
-            <p>This is the content of the popover.</p>
-        </LumexPopoverContent>
-    </LumexPopover>
-    );
-
-        var popoverTrigger = cut.FindComponent<LumexPopoverTrigger>();
-        var triggerButton = popoverTrigger.Find( "button" );
-
-        cut.Instance.Opened.Should().BeFalse( because: "An initial state" );
-
-        triggerButton.Click();
-
-        cut.Instance.Opened.Should().BeTrue( because: "The trigger is clicked" );
+        var id = "3";
+        var cut = Render(
+            @<text>
+                <LumexButton OnClick="@(() => TriggerAsync( id ))" data-popoverref="@id">
+                    Trigger
+                </LumexButton>
+                <LumexPopover Id="@id" Open="@true">
+                    <LumexPopoverContent>
+                        <p>This is the content of the popover.</p>
+                    </LumexPopoverContent>
+                </LumexPopover>
+            </text>
+        );
 
         cut.Find( "[data-popover]" ).TriggerEvent( "onclickoutside", new EventArgs() );
 
-        cut.Instance.Opened.Should().BeFalse( because: "An outside click occured" );
-    }
-
-    // [Fact]
-    // public void ShouldNotShowOnTriggeringShownOne()
-    // {
-    //     var cut = Render<LumexPopover>(
-    // @<LumexPopover>
-    //     <LumexPopoverTrigger>Show Popover</LumexPopoverTrigger>
-    //     <LumexPopoverContent>
-    //         <p>This is the content of the popover.</p>
-    //     </LumexPopoverContent>
-    // </LumexPopover>
-    //     );
-
-    //     var popoverTrigger = cut.FindComponent<LumexPopoverTrigger>();
-    //     var triggerButton = popoverTrigger.Find( "button" );
-
-    //     cut.Instance.Opened.Should().BeFalse( because: "An initial state" );
-
-    //     triggerButton.Click();
-
-    //     cut.Instance.Opened.Should().BeTrue( because: "The trigger is clicked" );
-
-    //     // Triggering the opened popover also triggers the 'clickoutside' event first
-    //     cut.Find( "[data-popover]" ).TriggerEvent( "onclickoutside", new EventArgs() );
-    //     triggerButton.Click();
-
-    //     cut.Instance.Opened.Should().BeFalse( because: "An outside click occured" );
-    // }
-
-    [Fact]
-    public void ShouldHidePopoverWhenOpeningAnotherOne()
-    {
-        var cut = Render(
-    @<text>
-        <LumexPopover>
-            <LumexPopoverTrigger>Show Popover</LumexPopoverTrigger>
-            <LumexPopoverContent>
-                <p>This is the content of the popover.</p>
-            </LumexPopoverContent>
-        </LumexPopover>
-        <LumexPopover>
-            <LumexPopoverTrigger>Show Popover 2</LumexPopoverTrigger>
-            <LumexPopoverContent>
-                <p>This is the content of the popover.</p>
-            </LumexPopoverContent>
-        </LumexPopover>
-    </text>
-        );
-
-        var popovers = cut.FindComponents<LumexPopover>();
-        var popoverTriggers = cut.FindComponents<LumexPopoverTrigger>();
-
-        popoverTriggers[0].Find( "button" ).Click();
-
-        popovers[0].Instance.Opened.Should().BeTrue();
-        popovers[1].Instance.Opened.Should().BeFalse();
-
-        // Triggering the 2nd popover also triggers the 'clickoutside' event first
-        popovers[0].Find( "[data-popover]" ).TriggerEvent( "onclickoutside", new EventArgs() );
-        popoverTriggers[1].Find( "button" ).Click();
-
-        popovers[0].Instance.Opened.Should().BeFalse();
-        popovers[1].Instance.Opened.Should().BeTrue();
+        var popover = cut.FindBySlot( "base" );
+        popover?.GetAttribute( "data-open" ).Should().Be( "false" );
     }
 
     [Fact]
     public void ShouldShowArrow()
     {
-        var cut = Render<LumexPopover>(
-    @<LumexPopover ShowArrow="@true">
-        <LumexPopoverTrigger>Show Popover</LumexPopoverTrigger>
-        <LumexPopoverContent>
-            <p>This is the content of the popover.</p>
-        </LumexPopoverContent>
-    </LumexPopover>
-    );
+        var id = "4";
+        var cut = Render(
+            @<text>
+                <LumexButton OnClick="@(() => TriggerAsync( id ))" data-popoverref="@id">
+                    Trigger
+                </LumexButton>
+                <LumexPopover Id="@id" ShowArrow="@true">
+                    <LumexPopoverContent>
+                        <p>This is the content of the popover.</p>
+                    </LumexPopoverContent>
+                </LumexPopover>
+            </text>
+         );
 
-        var popoverTrigger = cut.FindComponent<LumexPopoverTrigger>();
-        var triggerButton = popoverTrigger.Find( "button" );
+        var trigger = cut.Find( "[data-popoverref]" );
+        trigger.Click();
 
-        triggerButton.Click();
+        cut.FindBySlot( "arrow" ).Should().NotBeNull();
+    }
 
-        cut.Find( "[data-slot=arrow]" ).Should().NotBeNull();
+    private Task TriggerAsync( string id )
+    {
+        var popoverService = Services.GetRequiredService<IPopoverService>();
+        return popoverService.TriggerAsync( id );
     }
 }

--- a/tests/LumexUI.Tests/Components/Tooltip/TooltipTests.razor
+++ b/tests/LumexUI.Tests/Components/Tooltip/TooltipTests.razor
@@ -1,0 +1,72 @@
+﻿@namespace LumexUI.Tests.Components
+@inherits TestContext
+
+@code {
+    public TooltipTests()
+    {
+        Services.AddSingleton<TwMerge>();
+        Services.AddSingleton<IPopoverService, PopoverService>();
+
+        var module = JSInterop.SetupModule( "./_content/LumexUI/js/components/popover.bundle.js" );
+        module.SetupVoid( "popover.initialize", _ => true );
+        module.SetupVoid( "popover.destroy", _ => true );
+    }
+
+    [Fact]
+    public void ShouldRenderCorrectly()
+    {
+        var action = () => Render(
+            @<LumexTooltip>
+                <LumexButton>Hover me</LumexButton>
+            </LumexTooltip>
+        );
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ShouldThrowIfNoChildContentProvided()
+    {
+        var action = () => Render(
+            @<LumexTooltip Content="@("tooltip")" />
+        );
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData( "onmouseenter" )]
+    [InlineData( "onfocusin" )]
+    public void ShouldOpenOnEnterEvent( string e )
+    {
+        var cut = Render<LumexTooltip>(
+            @<LumexTooltip Content="@("tooltip")">
+                <LumexButton>Hover me</LumexButton>
+            </LumexTooltip>
+        );
+
+        var trigger = cut.Find( "[data-popoverref]" );
+        trigger.TriggerEvent( e, new EventArgs() );
+
+        cut.Instance.Open.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData( "onmouseleave" )]
+    [InlineData( "onfocusout" )]
+    public void ShouldCloseOnLeaveEvent( string e )
+    {
+        RenderFragment content = @<span>tooltip</span>;
+
+        var cut = Render<LumexTooltip>(
+            @<LumexTooltip Content="@content" Open="@true">
+                <LumexButton>Hover me</LumexButton>
+            </LumexTooltip>
+        );
+
+        var trigger = cut.Find( "[data-popoverref]" );
+        trigger.TriggerEvent( e, new EventArgs() );
+
+        cut.Instance.Open.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo! -->

## Description
<!--- 
    Provide a brief description of the changes in this pull request
    and mention related issues that this PR addresses or closes.
-->
Closes #177 

This PR adds a new Tooltip component.

### What's been done?
<!-- List the specific changes made in bullet-point format. -->

* {Change 1}
* {Change 2}
* ...
  
### Checklist
<!-- Make sure that you've checked all the items below before submitting the pull request. -->
- [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
- [x] I have included inline docs for my changes, where applicable.
- [x] I have added, updated or removed tests according to my changes.
- [x] All tests are passing.
- [x] There's an open issue for the PR that I am making.

### Additional Notes
<!-- 
    Any additional information that may be relevant to the 
    reviewer or the pull request as a whole. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Tooltip component with customizable appearance, placement, and arrow options.
  * Added comprehensive Tooltip documentation, interactive examples, and code previews.
  * Tooltip supports various sizes, colors, radii, shadows, placements, offsets, custom content, and two-way data binding.
  * New TooltipPlacement enum for flexible positioning.

* **Refactor**
  * Simplified and unified popover open/close logic and naming across related components.
  * Updated popover wrapper and context handling for improved stability and maintainability.

* **Bug Fixes**
  * Enhanced outside click detection for popovers and tooltips.

* **Tests**
  * Added extensive tests for Tooltip and updated Popover tests for improved coverage and reliability.

* **Documentation**
  * Expanded documentation with detailed Tooltip usage, customization, and API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->