### PR TITLE
feat(components): add Kbd component 

### DIFF
--- a/docs/LumexUI.Docs.Client/Common/Navigation/NavigationStore.cs
+++ b/docs/LumexUI.Docs.Client/Common/Navigation/NavigationStore.cs
@@ -34,6 +34,7 @@ public class NavigationStore
 			.Add( new( nameof( LumexDataGrid<T> ) ) )
 			.Add( new( nameof( LumexDivider ) ) )
 			.Add( new( nameof( LumexDropdown ) ) )
+			.Add( new( nameof( LumexKbd ), PageStatus.New ) )
 			.Add( new( nameof( LumexLink ) ) )
 			.Add( new( nameof( LumexListbox<T> ) ) )
 			.Add( new( nameof( LumexNavbar ) ) )

--- a/docs/LumexUI.Docs.Client/Pages/Components/Kbd/Examples/Keys.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Kbd/Examples/Keys.razor
@@ -1,0 +1,5 @@
+﻿<div class="flex items-center gap-2">
+	<LumexKbd Keys="@([KeyboardKey.Command])">K</LumexKbd>
+	<LumexKbd Keys="@([KeyboardKey.Command, KeyboardKey.Shift])">N</LumexKbd>
+	<LumexKbd Keys="@([KeyboardKey.Option, KeyboardKey.Command])">P</LumexKbd>
+</div>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Kbd/Examples/Usage.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Kbd/Examples/Usage.razor
@@ -1,0 +1,1 @@
+﻿<LumexKbd Keys="@([KeyboardKey.Command])">K</LumexKbd>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Kbd/Kbd.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Kbd/Kbd.razor
@@ -11,12 +11,15 @@
     </DocsSection>
 </DocsSection>
 
-<DocsSection Title="Custom Styles">
-    <p>
-        You can customize the Kbd component by passing any Tailwind CSS
-        classes to the component's <code>Class</code> parameter.
-    </p>
-</DocsSection>
+<DocsSlotsSection Slots="@_slots" >
+    <div>
+        <h4 class="font-semibold">Kbd</h4>
+        <ul>
+            <li><code>Class</code>: The basic CSS class name styles the wrapper of the kbd contents.</li>
+            <li><code>Classes</code>: The CSS class names for the kbd slots style the entire kbd at once.</li>
+        </ul>
+    </div>
+</DocsSlotsSection>
 
 <DocsApiSection Components="@_apiComponents" />
 
@@ -33,9 +36,9 @@
 
     private readonly Slot[] _slots = new Slot[]
     {
-        new("Base", "Kbd wrapper, it handles alignment, placement, and general appearance."),
-        new("Abbr", "The keys wrapper that handles the appearance of the keys."),
-        new("Content", "The children wrapper that handles the appearance of the content."),
+        new(nameof( KbdSlots.Base ), "Kbd wrapper, it handles alignment, placement, and general appearance."),
+        new(nameof( KbdSlots.Abbr ), "The keys wrapper that handles the appearance of the keys."),
+        new(nameof( KbdSlots.Content ), "The children wrapper that handles the appearance of the content."),
     };
 
     private readonly string[] _apiComponents = new string[]

--- a/docs/LumexUI.Docs.Client/Pages/Components/Kbd/Kbd.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Kbd/Kbd.razor
@@ -7,11 +7,12 @@
     <Usage />
 
     <DocsSection Title="Keys">
+        <p>Use the <code>Keys</code> parameter to specify a single keyboard key or a combination of keys.</p>
         <Keys />
     </DocsSection>
 </DocsSection>
 
-<DocsSlotsSection Slots="@_slots" >
+<DocsSlotsSection Slots="@_slots">
     <div>
         <h4 class="font-semibold">Kbd</h4>
         <ul>
@@ -31,6 +32,7 @@
         new("Usage", [
             new("Keys")
         ]),
+        new("Custom Styles"),
         new("API")
     };
 
@@ -43,17 +45,17 @@
 
     private readonly string[] _apiComponents = new string[]
     {
-        nameof(LumexKbd)
+        nameof( LumexKbd )
     };
 
     protected override void OnInitialized()
     {
         Layout.Initialize(
-            title: "Kbd",
+            title: "Keyboard Key",
             category: "Components",
             description: "Keyboard key component for displaying keyboard shortcuts and input combinations.",
             headings: _headings,
-            linksProps: new ComponentLinksProps("Kbd", isServer: true)
+            linksProps: new ComponentLinksProps( "Kbd", isServer: true )
         );
     }
 }

--- a/docs/LumexUI.Docs.Client/Pages/Components/Kbd/Kbd.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Kbd/Kbd.razor
@@ -1,0 +1,56 @@
+﻿@page "/docs/components/kbd"
+@layout DocsContentLayout
+
+@using LumexUI.Docs.Client.Pages.Components.Kbd.PreviewCodes
+
+<DocsSection Title="Usage">
+    <Usage />
+
+    <DocsSection Title="Keys">
+        <Keys />
+    </DocsSection>
+</DocsSection>
+
+<DocsSection Title="Custom Styles">
+    <p>
+        You can customize the Kbd component by passing any Tailwind CSS
+        classes to the component's <code>Class</code> parameter.
+    </p>
+</DocsSection>
+
+<DocsApiSection Components="@_apiComponents" />
+
+@code {
+    [CascadingParameter] private DocsContentLayout Layout { get; set; } = default!;
+
+    private readonly Heading[] _headings = new Heading[]
+    {
+        new("Usage", [
+            new("Keys")
+        ]),
+        new("API")
+    };
+
+    private readonly Slot[] _slots = new Slot[]
+    {
+        new("Base", "Kbd wrapper, it handles alignment, placement, and general appearance."),
+        new("Abbr", "The keys wrapper that handles the appearance of the keys."),
+        new("Content", "The children wrapper that handles the appearance of the content."),
+    };
+
+    private readonly string[] _apiComponents = new string[]
+    {
+        nameof(LumexKbd)
+    };
+
+    protected override void OnInitialized()
+    {
+        Layout.Initialize(
+            title: "Kbd",
+            category: "Components",
+            description: "Keyboard key component for displaying keyboard shortcuts and input combinations.",
+            headings: _headings,
+            linksProps: new ComponentLinksProps("Kbd", isServer: true)
+        );
+    }
+}

--- a/docs/LumexUI.Docs.Client/Pages/Components/Kbd/PreviewCodes/Keys.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Kbd/PreviewCodes/Keys.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new(name: null, snippet: "Kbd.Code.Keys")">
+    <LumexUI.Docs.Client.Pages.Components.Kbd.Examples.Keys />
+</PreviewCode>

--- a/docs/LumexUI.Docs.Client/Pages/Components/Kbd/PreviewCodes/Usage.razor
+++ b/docs/LumexUI.Docs.Client/Pages/Components/Kbd/PreviewCodes/Usage.razor
@@ -1,0 +1,5 @@
+﻿@rendermode InteractiveWebAssembly
+
+<PreviewCode Code="@new(name: null, snippet: "Kbd.Code.Usage")">
+    <LumexUI.Docs.Client.Pages.Components.Kbd.Examples.Usage />
+</PreviewCode>

--- a/src/LumexUI/Common/Enums/KeyboardKey.cs
+++ b/src/LumexUI/Common/Enums/KeyboardKey.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) LumexUI 2024
+// LumexUI licenses this file to you under the MIT license
+// See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
+
+namespace LumexUI.Common;
+
+/// <summary>
+/// Represents common keyboard keys for UI interactions.
+/// </summary>
+public enum KeyboardKey
+{
+	/// <summary>
+	/// The Command key (⌘), commonly found on Apple keyboards.
+	/// </summary>
+	Command,
+
+	/// <summary>
+	/// The Shift key.
+	/// </summary>
+	Shift,
+
+	/// <summary>
+	/// The Control key (Ctrl).
+	/// </summary>
+	Control,
+
+	/// <summary>
+	/// The Option key (⌥), commonly found on Apple keyboards.
+	/// </summary>
+	Option,
+
+	/// <summary>
+	/// The Enter key.
+	/// </summary>
+	Enter,
+
+	/// <summary>
+	/// The Delete key.
+	/// </summary>
+	Delete,
+
+	/// <summary>
+	/// The Escape key (Esc).
+	/// </summary>
+	Escape,
+
+	/// <summary>
+	/// The Tab key.
+	/// </summary>
+	Tab,
+
+	/// <summary>
+	/// The Caps Lock key.
+	/// </summary>
+	CapsLock,
+
+	/// <summary>
+	/// The Up Arrow key.
+	/// </summary>
+	Up,
+
+	/// <summary>
+	/// The Right Arrow key.
+	/// </summary>
+	Right,
+
+	/// <summary>
+	/// The Down Arrow key.
+	/// </summary>
+	Down,
+
+	/// <summary>
+	/// The Left Arrow key.
+	/// </summary>
+	Left,
+
+	/// <summary>
+	/// The Page Up key.
+	/// </summary>
+	PageUp,
+
+	/// <summary>
+	/// The Page Down key.
+	/// </summary>
+	PageDown,
+
+	/// <summary>
+	/// The Home key.
+	/// </summary>
+	Home,
+
+	/// <summary>
+	/// The End key.
+	/// </summary>
+	End,
+
+	/// <summary>
+	/// The Help key.
+	/// </summary>
+	Help,
+
+	/// <summary>
+	/// The Space key (Spacebar).
+	/// </summary>
+	Space,
+}

--- a/src/LumexUI/Common/Enums/KeyboardKey.cs
+++ b/src/LumexUI/Common/Enums/KeyboardKey.cs
@@ -30,6 +30,21 @@ public enum KeyboardKey
 	Option,
 
 	/// <summary>
+	/// The Alt key (⎇), commonly found on Windows and Linux keyboards.
+	/// </summary>
+	Alt,
+
+	/// <summary>
+	/// The Windows key (⊞).
+	/// </summary>
+	Win,
+
+	/// <summary>
+	/// The Function (fn) key, often found on laptops.
+	/// </summary>
+	Fn,
+
+	/// <summary>
 	/// The Enter key.
 	/// </summary>
 	Enter,

--- a/src/LumexUI/Components/Kbd/KbdConstants.cs
+++ b/src/LumexUI/Components/Kbd/KbdConstants.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) LumexUI 2024
+// LumexUI licenses this file to you under the MIT license
+// See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
+
+using LumexUI.Common;
+
+namespace LumexUI;
+
+/// <summary>
+/// Provides a collection of constants for mapping keyboard keys to their corresponding display symbols.
+/// </summary>
+public static class KbdConstants
+{
+	/// <summary>
+	/// Provides a mapping of keyboard keys to their corresponding display symbols for use in user interfaces or
+	/// documentation.
+	/// </summary>
+	public static readonly Dictionary<KeyboardKey, string> KeyboardKeys = new()
+	{
+		[KeyboardKey.Command] = "⌘",
+		[KeyboardKey.Shift] = "⇧",
+		[KeyboardKey.Control] = "⌃",
+		[KeyboardKey.Option] = "⌥",
+		[KeyboardKey.Alt] = "⎇",
+		[KeyboardKey.Win] = "⊞",
+		[KeyboardKey.Fn] = "fn",
+		[KeyboardKey.Enter] = "↵",
+		[KeyboardKey.Delete] = "⌫",
+		[KeyboardKey.Escape] = "⎋",
+		[KeyboardKey.Tab] = "⇥",
+		[KeyboardKey.CapsLock] = "⇪",
+		[KeyboardKey.Up] = "↑",
+		[KeyboardKey.Right] = "→",
+		[KeyboardKey.Down] = "↓",
+		[KeyboardKey.Left] = "←",
+		[KeyboardKey.PageUp] = "⇞",
+		[KeyboardKey.PageDown] = "⇟",
+		[KeyboardKey.Home] = "↖",
+		[KeyboardKey.End] = "↘",
+		[KeyboardKey.Help] = "?",
+		[KeyboardKey.Space] = "␣",
+	};
+}

--- a/src/LumexUI/Components/Kbd/KbdConstants.cs
+++ b/src/LumexUI/Components/Kbd/KbdConstants.cs
@@ -6,15 +6,8 @@ using LumexUI.Common;
 
 namespace LumexUI;
 
-/// <summary>
-/// Provides a collection of constants for mapping keyboard keys to their corresponding display symbols.
-/// </summary>
-public static class KbdConstants
+internal static class KbdConstants
 {
-	/// <summary>
-	/// Provides a mapping of keyboard keys to their corresponding display symbols for use in user interfaces or
-	/// documentation.
-	/// </summary>
 	public static readonly Dictionary<KeyboardKey, string> KeyboardKeys = new()
 	{
 		[KeyboardKey.Command] = "⌘",

--- a/src/LumexUI/Components/Kbd/KbdSlots.cs
+++ b/src/LumexUI/Components/Kbd/KbdSlots.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) LumexUI 2024
+// LumexUI licenses this file to you under the MIT license
+// See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
+
+using System.Diagnostics.CodeAnalysis;
+
+using LumexUI.Common;
+
+namespace LumexUI;
+
+/// <summary>
+/// Represents the slot names for the <see cref="LumexKbd"/>, 
+/// used to assign CSS classes to different parts of the component.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class KbdSlots : SlotBase
+{
+	/// <summary>
+	/// Gets or sets the CSS class for the abbr slot.
+	/// </summary>
+	public string? Abbr { get; set; }
+
+	/// <summary>
+	/// Gets or sets the CSS class for the content slot.
+	/// </summary>
+	public string? Content { get; set; }
+}

--- a/src/LumexUI/Components/Kbd/KbdSlots.cs
+++ b/src/LumexUI/Components/Kbd/KbdSlots.cs
@@ -9,8 +9,7 @@ using LumexUI.Common;
 namespace LumexUI;
 
 /// <summary>
-/// Represents the slot names for the <see cref="LumexKbd"/>, 
-/// used to assign CSS classes to different parts of the component.
+/// Represents the set of customizable slots for the <see cref="LumexKbd"/> component.
 /// </summary>
 [ExcludeFromCodeCoverage]
 public class KbdSlots : SlotBase

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor
@@ -2,15 +2,18 @@
 @inherits LumexComponentBase
 
 @using S = KbdSlots;
+@using C = KbdConstants;
 
-<LumexComponent As="@As" 
+<LumexComponent As="@As"
 				Class="@GetStyles( nameof( S.Base ) )"
 				Style="@RootStyle"
 				@attributes="AdditionalAttributes">
 	@foreach (var key in Keys)
 	{
-		<abbr class="@GetStyles( nameof( S.Abbr ) )" title="@key">@GetKeySymbol(key)</abbr>
+		<abbr class="@GetStyles(nameof(S.Abbr))" title="@key">
+			@C.KeyboardKeys[key]
+		</abbr>
 	}
 
-	<span class="@GetStyles( nameof( S.Content ) )">@ChildContent</span>
+	<span class="@GetStyles(nameof(S.Content))">@ChildContent</span>
 </LumexComponent>

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor
@@ -5,23 +5,18 @@
 @using C = KbdConstants;
 
 <LumexComponent As="@As"
-				Class="@GetStyles( nameof( S.Base ) )"
-				Style="@RootStyle"
-				data-slot="kbd"
-				@attributes="AdditionalAttributes">
+                Class="@GetStyles( nameof( S.Base ) )"
+                Style="@RootStyle"
+                data-slot="base"
+                @attributes="@AdditionalAttributes">
+    @foreach( var key in Keys )
+    {
+        <abbr class="@GetStyles( nameof( S.Abbr ) )" title="@key" data-slot="abbr">
+            @( C.KeyboardKeys.TryGetValue( key, out var symbol ) ? symbol : null )
+        </abbr>
+    }
 
-	@foreach ( var key in Keys )
-	{
-		<abbr class="@GetStyles( nameof( S.Abbr ) )"
-			  title="@key"
-			  data-slot="abbr">
-			@( C.KeyboardKeys.TryGetValue( key, out var symbol ) ? symbol : null )
-		</abbr>
-	}
-
-	<span class="@GetStyles( nameof( S.Content ) )"
-		  data-slot="content">
-		@ChildContent
-	</span>
-
+    <span class="@GetStyles( nameof( S.Content ) )" data-slot="content">
+        @ChildContent
+    </span>
 </LumexComponent>

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor
@@ -1,0 +1,2 @@
+@namespace LumexUI
+@inherits LumexComponentBase

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor
@@ -6,7 +6,7 @@
 <LumexComponent As="@As" Class="@GetStyles( nameof( S.Base ) )">
 	@foreach (var key in Keys)
 	{
-		<abbr class="@GetStyles( nameof( S.Abbr ) )">@key</abbr>
+		<abbr class="@GetStyles( nameof( S.Abbr ) )" title="@key">@GetKeySymbol(key)</abbr>
 	}
 
 	<span class="@GetStyles( nameof( S.Content ) )">@ChildContent</span>

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor
@@ -1,2 +1,13 @@
 @namespace LumexUI
 @inherits LumexComponentBase
+
+@using S = KbdSlots;
+
+<LumexComponent As="@As" Class="@GetStyles( nameof( S.Base ) )">
+	@foreach (var key in Keys)
+	{
+		<abbr class="@GetStyles( nameof( S.Abbr ) )">@key</abbr>
+	}
+
+	<span class="@GetStyles( nameof( S.Content ) )">@ChildContent</span>
+</LumexComponent>

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor
@@ -3,7 +3,10 @@
 
 @using S = KbdSlots;
 
-<LumexComponent As="@As" Class="@GetStyles( nameof( S.Base ) )">
+<LumexComponent As="@As" 
+				Class="@GetStyles( nameof( S.Base ) )"
+				Style="@RootStyle"
+				@attributes="AdditionalAttributes">
 	@foreach (var key in Keys)
 	{
 		<abbr class="@GetStyles( nameof( S.Abbr ) )" title="@key">@GetKeySymbol(key)</abbr>

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor
@@ -7,13 +7,21 @@
 <LumexComponent As="@As"
 				Class="@GetStyles( nameof( S.Base ) )"
 				Style="@RootStyle"
+				data-slot="kbd"
 				@attributes="AdditionalAttributes">
-	@foreach (var key in Keys)
+
+	@foreach ( var key in Keys )
 	{
-		<abbr class="@GetStyles(nameof(S.Abbr))" title="@key">
+		<abbr class="@GetStyles( nameof( S.Abbr ) )"
+			  title="@key"
+			  data-slot="abbr">
 			@C.KeyboardKeys[key]
 		</abbr>
 	}
 
-	<span class="@GetStyles(nameof(S.Content))">@ChildContent</span>
+	<span class="@GetStyles( nameof( S.Content ) )"
+		  data-slot="content">
+		@ChildContent
+	</span>
+
 </LumexComponent>

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor
@@ -15,7 +15,7 @@
 		<abbr class="@GetStyles( nameof( S.Abbr ) )"
 			  title="@key"
 			  data-slot="abbr">
-			@C.KeyboardKeys[key]
+			@( C.KeyboardKeys.TryGetValue( key, out var symbol ) ? symbol : null )
 		</abbr>
 	}
 

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Components;
 namespace LumexUI;
 
 /// <summary>
-/// <see cref="LumexKbd"/> is a component to display which key or combination of keys performs a given action.
+/// A component that represents a keyboard key or combination of keys used to perform a specific action.
 /// </summary>
 public partial class LumexKbd : LumexComponentBase, ISlotComponent<KbdSlots>
 {

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
@@ -48,34 +48,6 @@ public partial class LumexKbd : LumexComponentBase, ISlotComponent<KbdSlots>
 		_slots = kbd();
 	}
 
-	private static string? GetKeySymbol( KeyboardKey key )
-	{
-		// It's better a dictionary?
-		return key switch
-		{
-			KeyboardKey.Command => "⌘",
-			KeyboardKey.Shift => "⇧",
-			KeyboardKey.Control => "⌃",
-			KeyboardKey.Option => "⌥",
-			KeyboardKey.Enter => "↵",
-			KeyboardKey.Delete => "⌫",
-			KeyboardKey.Escape => "⎋",
-			KeyboardKey.Tab => "⇥",
-			KeyboardKey.CapsLock => "⇪",
-			KeyboardKey.Up => "↑",
-			KeyboardKey.Right => "→",
-			KeyboardKey.Down => "↓",
-			KeyboardKey.Left => "←",
-			KeyboardKey.PageUp => "⇞",
-			KeyboardKey.PageDown => "⇟",
-			KeyboardKey.Home => "↖",
-			KeyboardKey.End => "↘",
-			KeyboardKey.Help => "?",
-			KeyboardKey.Space => "␣",
-			_ => null
-		};
-	}
-
 	[ExcludeFromCodeCoverage]
 	private string? GetStyles( string slot )
 	{

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) LumexUI 2024
+// LumexUI licenses this file to you under the MIT license
+// See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
+
+using LumexUI.Common;
+
+namespace LumexUI;
+
+/// <summary>
+/// <see cref="LumexKbd"/> is a component to display which key or combination of keys performs a given action.
+/// </summary>
+public partial class LumexKbd : LumexComponentBase, ISlotComponent<KbdSlots>
+{
+	/// <summary>
+	/// Gets or sets the CSS class names for the kbd slots.
+	/// </summary>
+	public KbdSlots? Classes { get; }
+}

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
@@ -3,7 +3,6 @@
 // See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
 
 using System.Diagnostics.CodeAnalysis;
-using System.Drawing;
 
 using LumexUI.Common;
 using LumexUI.Utilities;
@@ -30,7 +29,7 @@ public partial class LumexKbd : LumexComponentBase, ISlotComponent<KbdSlots>
 	/// <summary>
 	/// Gets or sets the collection of keys to be used as input for the component.
 	/// </summary>
-	[Parameter] public IEnumerable<string> Keys { get; set; } = [];
+	[Parameter] public IEnumerable<KeyboardKey> Keys { get; set; } = [];
 
 	private Dictionary<string, ComponentSlot> _slots = [];
 
@@ -44,6 +43,34 @@ public partial class LumexKbd : LumexComponentBase, ISlotComponent<KbdSlots>
 	{
 		var kbd = Styles.Kbd.Style( TwMerge );
 		_slots = kbd();
+	}
+
+	private static string? GetKeySymbol( KeyboardKey key )
+	{
+		// It's better a dictionary?
+		return key switch
+		{
+			KeyboardKey.Command => "⌘",
+			KeyboardKey.Shift => "⇧",
+			KeyboardKey.Control => "⌃",
+			KeyboardKey.Option => "⌥",
+			KeyboardKey.Enter => "↵",
+			KeyboardKey.Delete => "⌫",
+			KeyboardKey.Escape => "⎋",
+			KeyboardKey.Tab => "⇥",
+			KeyboardKey.CapsLock => "⇪",
+			KeyboardKey.Up => "↑",
+			KeyboardKey.Right => "→",
+			KeyboardKey.Down => "↓",
+			KeyboardKey.Left => "←",
+			KeyboardKey.PageUp => "⇞",
+			KeyboardKey.PageDown => "⇟",
+			KeyboardKey.Home => "↖",
+			KeyboardKey.End => "↘",
+			KeyboardKey.Help => "?",
+			KeyboardKey.Space => "␣",
+			_ => null
+		};
 	}
 
 	[ExcludeFromCodeCoverage]

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
@@ -22,19 +22,19 @@ public partial class LumexKbd : LumexComponentBase, ISlotComponent<KbdSlots>
 	[Parameter] public RenderFragment? ChildContent { get; set; }
 
 	/// <summary>
-	/// Gets or sets the CSS class names for the kbd slots.
-	/// </summary>
-	[Parameter] public KbdSlots? Classes { get; set; }
-
-	/// <summary>
 	/// Gets or sets the collection of keys to be used as input for the component.
 	/// </summary>
 	[Parameter] public IEnumerable<KeyboardKey> Keys { get; set; } = [];
 
+	/// <summary>
+	/// Gets or sets the CSS class names for the kbd slots.
+	/// </summary>
+	[Parameter] public KbdSlots? Classes { get; set; }
+
 	private Dictionary<string, ComponentSlot> _slots = [];
 
 	/// <summary>
-	/// Initializes a new instance of the <see cref="LumexKbd"/> class, representing a keyboard element.
+	/// Initializes a new instance of the <see cref="LumexKbd"/>.
 	/// </summary>
 	public LumexKbd()
 	{

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
@@ -33,6 +33,9 @@ public partial class LumexKbd : LumexComponentBase, ISlotComponent<KbdSlots>
 
 	private Dictionary<string, ComponentSlot> _slots = [];
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="LumexKbd"/> class, representing a keyboard element.
+	/// </summary>
 	public LumexKbd()
 	{
 		As = "kbd";

--- a/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
+++ b/src/LumexUI/Components/Kbd/LumexKbd.razor.cs
@@ -2,7 +2,13 @@
 // LumexUI licenses this file to you under the MIT license
 // See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
 
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+
 using LumexUI.Common;
+using LumexUI.Utilities;
+
+using Microsoft.AspNetCore.Components;
 
 namespace LumexUI;
 
@@ -12,7 +18,48 @@ namespace LumexUI;
 public partial class LumexKbd : LumexComponentBase, ISlotComponent<KbdSlots>
 {
 	/// <summary>
+	/// Gets or sets the content to be rendered inside the component.
+	/// </summary>
+	[Parameter] public RenderFragment? ChildContent { get; set; }
+
+	/// <summary>
 	/// Gets or sets the CSS class names for the kbd slots.
 	/// </summary>
-	public KbdSlots? Classes { get; }
+	[Parameter] public KbdSlots? Classes { get; set; }
+
+	/// <summary>
+	/// Gets or sets the collection of keys to be used as input for the component.
+	/// </summary>
+	[Parameter] public IEnumerable<string> Keys { get; set; } = [];
+
+	private Dictionary<string, ComponentSlot> _slots = [];
+
+	public LumexKbd()
+	{
+		As = "kbd";
+	}
+
+	/// <inheritdoc/>
+	protected override void OnParametersSet()
+	{
+		var kbd = Styles.Kbd.Style( TwMerge );
+		_slots = kbd();
+	}
+
+	[ExcludeFromCodeCoverage]
+	private string? GetStyles( string slot )
+	{
+		if( !_slots.TryGetValue( slot, out var styles ) )
+		{
+			throw new NotImplementedException();
+		}
+
+		return slot switch
+		{
+			nameof( KbdSlots.Base ) => styles( Classes?.Base, Class ),
+			nameof( KbdSlots.Abbr ) => styles( Classes?.Abbr ),
+			nameof( KbdSlots.Content ) => styles( Classes?.Content ),
+			_ => throw new NotImplementedException()
+		};
+	}
 }

--- a/src/LumexUI/Styles/Kbd.cs
+++ b/src/LumexUI/Styles/Kbd.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) LumexUI 2024
+// LumexUI licenses this file to you under the MIT license
+// See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
+
+using System.Diagnostics.CodeAnalysis;
+
+using LumexUI.Utilities;
+
+using TailwindMerge;
+
+namespace LumexUI.Styles;
+
+[ExcludeFromCodeCoverage]
+internal static class Kbd
+{
+	private static ComponentVariant? _variant;
+
+	public static ComponentVariant Style( TwMerge twMerge )
+	{
+		var twVariants = new TwVariants( twMerge );
+
+		return _variant ??= twVariants.Create( new VariantConfig()
+		{
+			Slots = new SlotCollection
+			{
+				[nameof( KbdSlots.Base )] = new ElementClass()
+					.Add( "px-1.5" )
+					.Add( "py-0.5" )
+					.Add( "inline-flex" )
+					.Add( "space-x-0.5" )
+					.Add( "rtl:space-x-reverse" )
+					.Add( "items-center" )
+					.Add( "font-sans" )
+					.Add( "font-normal" )
+					.Add( "text-center" )
+					.Add( "text-small" )
+					.Add( "shadow-small" )
+					.Add( "bg-default-100" )
+					.Add( "text-foreground-600" )
+					.Add( "rounded-small" ),
+
+				[nameof( KbdSlots.Abbr )] = "no-underline",
+			}
+		} );
+	}
+}

--- a/src/LumexUI/Styles/Kbd.cs
+++ b/src/LumexUI/Styles/Kbd.cs
@@ -40,6 +40,8 @@ internal static class Kbd
 					.Add( "rounded-small" ),
 
 				[nameof( KbdSlots.Abbr )] = "no-underline",
+
+				[nameof( KbdSlots.Content )] = "",
 			}
 		} );
 	}

--- a/tests/LumexUI.Tests/Components/Kbd/KbdTests.razor
+++ b/tests/LumexUI.Tests/Components/Kbd/KbdTests.razor
@@ -1,8 +1,6 @@
 ﻿@namespace LumexUI.Tests.Components
 @inherits TestContext
 
-@using LumexUI.Styles
-
 @code {
     public KbdTests()
     {
@@ -22,8 +20,6 @@
     [Fact]
     public void ShouldRenderChildrenAndContent()
     {
-        RenderFragment content = @<span data-testid="kbd-children" />;
-
         var cut = Render(
             @<LumexKbd Keys="@([KeyboardKey.Command])" data-testid="kbd-root">
                 <span data-testid="kbd-children">
@@ -32,27 +28,21 @@
             </LumexKbd>
         );
 
-        cut.FindByTestId("kbd-root").Should().NotBeNull();
-        cut.FindByTestId("kbd-children").Should().NotBeNull();
+        cut.FindByTestId( "kbd-root" ).Should().NotBeNull();
+        cut.FindByTestId( "kbd-children" ).Should().NotBeNull();
     }
 
     [Fact]
     public void ShouldRenderMultipleKeys()
     {
-        // Arrange: render LumexKbd with multiple keys
         var cut = Render(
-            @<LumexKbd Keys="@([KeyboardKey.Command, KeyboardKey.Shift])" data-testid="kbd-multikeys">
+            @<LumexKbd Keys="@([KeyboardKey.Command, KeyboardKey.Shift])">
                 K
             </LumexKbd>
         );
 
-        // Act: find the root element
-        var root = cut.FindByTestId("kbd-multikeys");
-        root.Should().NotBeNull();
+        var kbd = cut.FindBySlot( "base" );
 
-        // Assert: check that all key symbols are rendered
-        root.InnerHtml.Should().Contain("⌘");
-        root.InnerHtml.Should().Contain("⇧");
-        root.InnerHtml.Should().Contain("K");
+        kbd!.TextContent.Should().ContainAll( "⌘", "⇧", "K" );
     }
 }

--- a/tests/LumexUI.Tests/Components/Kbd/KbdTests.razor
+++ b/tests/LumexUI.Tests/Components/Kbd/KbdTests.razor
@@ -1,0 +1,58 @@
+﻿@namespace LumexUI.Tests.Components
+@inherits TestContext
+
+@using LumexUI.Styles
+
+@code {
+    public KbdTests()
+    {
+        Services.AddSingleton<TwMerge>();
+    }
+
+    [Fact]
+    public void ShouldRenderCorrectly()
+    {
+        var action = () => Render(
+            @<LumexKbd Keys="@([KeyboardKey.Command])">K</LumexKbd>
+        );
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ShouldRenderChildrenAndContent()
+    {
+        RenderFragment content = @<span data-testid="kbd-children" />;
+
+        var cut = Render(
+            @<LumexKbd Keys="@([KeyboardKey.Command])" data-testid="kbd-root">
+                <span data-testid="kbd-children">
+                    K
+                </span>
+            </LumexKbd>
+        );
+
+        cut.FindByTestId("kbd-root").Should().NotBeNull();
+        cut.FindByTestId("kbd-children").Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ShouldRenderMultipleKeys()
+    {
+        // Arrange: render LumexKbd with multiple keys
+        var cut = Render(
+            @<LumexKbd Keys="@([KeyboardKey.Command, KeyboardKey.Shift])" data-testid="kbd-multikeys">
+                K
+            </LumexKbd>
+        );
+
+        // Act: find the root element
+        var root = cut.FindByTestId("kbd-multikeys");
+        root.Should().NotBeNull();
+
+        // Assert: check that all key symbols are rendered
+        root.InnerHtml.Should().Contain("⌘");
+        root.InnerHtml.Should().Contain("⇧");
+        root.InnerHtml.Should().Contain("K");
+    }
+}


### PR DESCRIPTION
## Description

### What's been done?

* Added the `Kbd` component, adapted from HeroUI, into the LumexUI component library.
* Implemented props and styling consistent with LumexUI’s design system.
* Wrote inline documentation and usage examples for the `Kbd` component.
* Added unit tests to cover rendering, props, and edge cases.

### Checklist

* [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
* [x] I have included inline docs for my changes, where applicable.
* [x] I have added, updated or removed tests according to my changes.
* [x] All tests are passing.
* [ ] There's an open issue for the PR that I am making.

### Additional Notes

No additional notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Kbd component to render keyboard keys/combinations with glyphs, multiple-key support, and slot-based styling.
  * Added a KeyboardKey enum and a built-in key-to-glyph mapping for consistent symbols.

* **Documentation**
  * Added a Kbd docs page with usage, API, slots, and interactive examples; navigation now includes Kbd.

* **Styles**
  * Added default styling variant for Kbd (spacing, typography, visuals).

* **Tests**
  * Added tests validating rendering, child content, and multi-key display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->