### PR TITLE
feat(components): Popover exit animation

### DIFF
--- a/src/LumexUI/Components/Popover/LumexPopover.razor.cs
+++ b/src/LumexUI/Components/Popover/LumexPopover.razor.cs
@@ -99,6 +99,7 @@ public partial class LumexPopover : LumexComponentBase, ISlotComponent<PopoverSl
 	/// </summary>
 	[Parameter] public PopoverSlots? Classes { get; set; }
 
+	internal bool IsVisible { get; set; }
 	internal bool IsTooltip { get; private set; }
 	internal PopoverOptions Options { get; private set; }
 	internal Dictionary<string, ComponentSlot> Slots { get; private set; } = [];
@@ -124,6 +125,11 @@ public partial class LumexPopover : LumexComponentBase, ISlotComponent<PopoverSl
 		if( AdditionalAttributes?.TryGetValue( "role", out var value ) ?? false )
 		{
 			IsTooltip = value is "tooltip";
+		}
+
+		if( Open && !IsVisible )
+		{
+			IsVisible = true;
 		}
 
 		Options = new PopoverOptions( this );
@@ -157,6 +163,7 @@ public partial class LumexPopover : LumexComponentBase, ISlotComponent<PopoverSl
 	internal Task OpenAsync()
 	{
 		Open = true;
+		IsVisible = true;
 		return OpenChanged.InvokeAsync( true );
 	}
 

--- a/src/LumexUI/Components/Popover/LumexPopoverContent.razor
+++ b/src/LumexUI/Components/Popover/LumexPopoverContent.razor
@@ -1,9 +1,11 @@
 ﻿@namespace LumexUI
 @inherits LumexComponentBase
 
-@if( Popover.Open )
+@if( Popover.IsVisible )
 {
-    <PopoverWrapper Class="@Popover.Slots["Wrapper"]()">
+    <PopoverWrapper Class="@Popover.Slots["Wrapper"]()"
+                    data-popover-open="@Popover.Open.ToAttributeValue()"
+                    @onanimationend="HandleAnimationEnd">
         <div role="dialog"
              class="@Popover.Slots["Base"]( Popover.Classes?.Base, Popover.Class )"
              tabindex="-1"
@@ -11,7 +13,7 @@
              data-open="@Popover.Open.ToAttributeValue()"
              @attributes="@Popover.AdditionalAttributes">
             <LumexComponent As="@As"
-                            Class="@Popover.Slots["Content"](Popover.Classes?.Content, Class)"
+                            Class="@Popover.Slots["Content"]( Popover.Classes?.Content, Class )"
                             Style="@RootStyle"
                             data-slot="content"
                             @attributes="@AdditionalAttributes">

--- a/src/LumexUI/Components/Popover/LumexPopoverContent.razor.cs
+++ b/src/LumexUI/Components/Popover/LumexPopoverContent.razor.cs
@@ -3,6 +3,7 @@
 // See the license here https://github.com/LumexUI/lumexui/blob/main/LICENSE
 
 using LumexUI.Common;
+using LumexUI.Infrastructure;
 
 using Microsoft.AspNetCore.Components;
 
@@ -27,5 +28,14 @@ public partial class LumexPopoverContent : LumexComponentBase
 	protected override void OnInitialized()
 	{
 		ContextNullException.ThrowIfNull( Context, nameof( LumexPopoverContent ) );
+	}
+
+	private async Task HandleAnimationEnd( AnimationEventArgs e )
+	{
+		if( !Popover.Open && e.AnimationName.Contains( "exit", StringComparison.OrdinalIgnoreCase ) )
+		{
+			Popover.IsVisible = false;
+			await InvokeAsync( StateHasChanged );
+		}
 	}
 }

--- a/src/LumexUI/Infrastructure/EventHandlers.cs
+++ b/src/LumexUI/Infrastructure/EventHandlers.cs
@@ -10,6 +10,26 @@ namespace LumexUI.Infrastructure;
 /// Configures event handlers for the components.
 /// </summary>
 [EventHandler( "onclickoutside", typeof( EventArgs ), enableStopPropagation: true, enablePreventDefault: true )]
+[EventHandler( "onanimationend", typeof( AnimationEventArgs ), enableStopPropagation: true, enablePreventDefault: true )]
 public static class EventHandlers
 {
+}
+
+/// <summary>
+/// Arguments for the animation events.
+/// </summary>
+public class AnimationEventArgs : EventArgs
+{
+	/// <summary>
+	/// Gets the name of the animation.
+	/// </summary>
+	public string AnimationName { get; set; } = string.Empty;
+	/// <summary>
+	/// Gets the elapsed time of the animation in seconds.
+	/// </summary>
+	public double ElapsedTime { get; set; }
+	/// <summary>
+	/// Gets the name of the pseudo-element the animation is applied to.
+	/// </summary>
+	public string PseudoElement { get; set; } = string.Empty;
 }

--- a/src/LumexUI/Styles/Popover.cs
+++ b/src/LumexUI/Styles/Popover.cs
@@ -31,7 +31,8 @@ internal static class Popover
 					.ToString(),
 
 				["Wrapper"] = new ElementClass()
-					.Add( "animate-enter" )
+					.Add( "data-[popover-open=true]:animate-enter" )
+					.Add( "data-[popover-open=false]:animate-exit" )
 					.ToString(),
 
 				[nameof( PopoverSlots.Content )] = new ElementClass()

--- a/src/LumexUI/Styles/_theme.css
+++ b/src/LumexUI/Styles/_theme.css
@@ -172,6 +172,7 @@
 
     /* Animations */
     --animate-enter: enter 150ms ease-out normal both;
+    --animate-exit: exit 150ms ease-out normal both;
     --animate-shimmer: shimmer 2s infinite;
     --animate-sway: sway 0.75s infinite;
     --animate-blink: blink 1.5s infinite both;
@@ -186,6 +187,18 @@
         100% {
             opacity: 1;
             transform: translateZ(0) scale(1);
+        }
+    }
+
+    @keyframes exit {
+        0% {
+            opacity: 1;
+            transform: translateZ(0) scale(1);
+        }
+
+        100% {
+            opacity: 0;
+            transform: translateZ(0)  scale(0.85);
         }
     }
 

--- a/src/LumexUI/wwwroot/js/LumexUI.js
+++ b/src/LumexUI/wwwroot/js/LumexUI.js
@@ -9,3 +9,14 @@ export const Lumex = {
 };
 
 window['Lumex'] = Lumex
+
+Blazor.registerCustomEventType('animationend', {
+    browserEventName: 'animationend',
+    createEventArgs: event => {
+        return {
+            AnimationName: event.animationName,
+            ElapsedTime: event.elapsedTime,
+            PseudoElement: event.pseudoElement
+        };
+    }
+})

--- a/tests/LumexUI.Tests/Components/Dropdown/DropdownTests.razor
+++ b/tests/LumexUI.Tests/Components/Dropdown/DropdownTests.razor
@@ -133,7 +133,7 @@
         var menuItems = cut.FindAll( "li" );
         menuItems[0].Click();
 
-        var menu = cut.FindByTestId( "menu-test" );
+        var menu = cut.FindByTestId("menu-test");
         menu.Should().BeNull();
     }
 


### PR DESCRIPTION
## Description
Add the ability to have a popover exit animation.

### What's been done?

* Added 'onanimationend' custom blazor handling
* Added '--animation-exit' css variable
* Handled animation delay on popover
  
### Checklist
- [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
- [x] I have included inline docs for my changes, where applicable.
- [x] I have added, updated or removed tests according to my changes.
- [ ] All tests are passing.
- [ ] There's an open issue for the PR that I am making.

### Additional Notes
There is one test that the dropdown is failing even though visually it works well. I needed to add the custom handling in the LumexUI.js if it's not the correct place I can change it
