### PR TITLE
fix(toast): use app's font sans family by default

### DIFF
--- a/src/LumexUI/Styles/ToastProvider.cs
+++ b/src/LumexUI/Styles/ToastProvider.cs
@@ -14,6 +14,7 @@ internal static class ToastProvider
 	public static string Style()
 	{
 		return new ElementClass()
+			.Add( "font-sans!" )
 			.Add( "[--normal-bg:var(--lumex-surface1)]!" )
 			.Add( "[--normal-text:var(--lumex-surface1-foreground)]!" )
 			.Add( "[--normal-border:var(--lumex-default-200)]!" )


### PR DESCRIPTION
Closes #278 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated toast notification styling to use a sans-serif font for improved visual consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->