### PR TITLE
fix(modal): disable exit transition if `overlay` is not supported (webkit/safari)

### DIFF
--- a/src/LumexUI/Styles/Modal.cs
+++ b/src/LumexUI/Styles/Modal.cs
@@ -48,7 +48,9 @@ internal static class Modal
 					.Add( "backdrop:duration-150" )
 					.Add( "backdrop:transition-opacity" )
 					.Add( "starting:backdrop:opacity-0" )
-					.Add( "not-open:backdrop:opacity-0" ),
+					.Add( "not-open:backdrop:opacity-0" )
+					// compatibility (WebKit/Safari)
+					.Add( "not-open:not-supports-[overlay:auto]:duration-0" ),
 
 		[nameof( ModalSlots.Trigger )] = new ElementClass(),
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo! -->

## Description
<!--- 
    Provide a brief description of the changes in this pull request
    and mention related issues that this PR addresses or closes.
-->
This PR addresses a bug [reported in Discord](https://discord.com/channels/1310668690337038346/1310668690337038352/1476308502682144768) regarding the Modal component being removed from the top layer too early, which caused it to be “dropped under” other positioned elements.

### What's been done?
<!-- List the specific changes made in bullet-point format. -->

* Added a CSS `@supports` rule to disable exit transitions if `overlay` is not supported (WebKit).
  
### Checklist
<!-- Make sure that you've checked all the items below before submitting the pull request. -->
- [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
- [x] I have included inline docs for my changes, where applicable.
- [ ] I have added, updated or removed tests according to my changes.
- [x] All tests are passing.
- [x] There's an open issue for the PR that I am making.

### Additional Notes
<!-- 
    Any additional information that may be relevant to the 
    reviewer or the pull request as a whole. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal backdrop styling and Safari browser compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->