### PR TITLE
fix(link): ensure disabled links are actually disabled when tab-navigated

### DIFF
--- a/src/LumexUI/Components/Link/LumexLink.razor.cs
+++ b/src/LumexUI/Components/Link/LumexLink.razor.cs
@@ -69,12 +69,21 @@ public partial class LumexLink : LumexComponentBase
 	{
 		get
 		{
-			var attributes = new Dictionary<string, object>()
-			{
-				["href"] = Href
-			};
+			var attributes = new Dictionary<string, object>();
 
-			if( External )
+			// Only add href if not disabled
+			if( !Disabled )
+			{
+				attributes["href"] = Href;
+			}
+			else
+			{
+				// For disabled links, add accessibility attributes
+				attributes["tabindex"] = "-1";
+				attributes["aria-disabled"] = "true";
+			}
+
+			if( External && !Disabled )
 			{
 				attributes["target"] = "_blank";
 				attributes["rel"] = "noopener noreferrer";


### PR DESCRIPTION
Closes #137 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link component accessibility: disabled links now properly prevent navigation and include accessibility attributes (aria-disabled, tabindex) for assistive technologies. External link attributes are correctly managed based on disabled state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->