### PR TITLE
docs(*): set fixed version for apexcharts

### DIFF
--- a/docs/LumexUI.Docs/Components/App.razor
+++ b/docs/LumexUI.Docs/Components/App.razor
@@ -27,7 +27,7 @@
         <Routes />
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/apexcharts" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/apexcharts@5.3.6/dist/apexcharts.min.js" defer></script>
     <script src="js/docs.js"></script>
     <script src="js/prism.js"></script>
     <script src="_content/LumexUI/js/LumexUI.js" type="module"></script>


### PR DESCRIPTION
This PR addresses an issue where ApexCharts were not properly colorized on the Home page. It turned out that the way colors are applied to series has changed, so I pinned the package to the previously working version instead of taking the latest.

**Before**

<img width="753" height="285" alt="image" src="https://github.com/user-attachments/assets/12aef398-59d4-48e1-aaed-a5cecf6c9403" />

**After**

<img width="758" height="286" alt="image" src="https://github.com/user-attachments/assets/00f356b9-3141-4145-8bd2-2ad617de3778" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated ApexCharts library dependency to a specific version to ensure consistent chart rendering and prevent unexpected behavior variations across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->