### PR TITLE
fix(styles): scope scroll-lock to dialog elements only

### DIFF
--- a/src/LumexUI/Styles/_theme.css
+++ b/src/LumexUI/Styles/_theme.css
@@ -8,7 +8,7 @@
 
 @layer base {
     html {
-        @apply has-open:overflow-hidden has-open:[scrollbar-gutter:stable];
+        @apply has-[dialog[open]]:overflow-hidden has-[dialog[open]]:[scrollbar-gutter:stable];
     }
 
     body {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo! -->

## Description
<!--- 
    Provide a brief description of the changes in this pull request
    and mention related issues that this PR addresses or closes.
-->
Closes #297

The `has-open` Tailwind variant on the `html` element matched any element with `[open]` or `:popover-open`, including native date pickers which use the Popover API internally. This caused the page scrollbar to be removed when opening a `LumexDatebox` and not restored when closing it.

### What's been done?
<!-- List the specific changes made in bullet-point format. -->

* Narrow the selector to `has-[dialog[open]]` so that scroll-locking only applies when a `<dialog>` element is open (i.e., LumexModal).
  
### Checklist
<!-- Make sure that you've checked all the items below before submitting the pull request. -->
- [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
- [x] I have included inline docs for my changes, where applicable.
- [x] I have added, updated or removed tests according to my changes.
- [x] All tests are passing.
- [x] There's an open issue for the PR that I am making.

### Additional Notes
<!-- 
    Any additional information that may be relevant to the 
    reviewer or the pull request as a whole. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scrollbar behavior when dialogs are displayed. Enhanced theme styling to prevent unwanted background scrolling when modal dialogs are opened, maintain stable layout spacing without jarring visual shifts, and improve overall visual stability during dialog interactions. This delivers a more polished user experience when working with modals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->