### PR TITLE
fix(popover): portal into closest dialog to stay on top layer

### DIFF
--- a/src/LumexUI/wwwroot/js/components/popover.bundle.js
+++ b/src/LumexUI/wwwroot/js/components/popover.bundle.js
@@ -1619,17 +1619,19 @@ function waitForElement(selector) {
     });
 }
 
-function portal(element, selector = undefined) {
+function portal(element, destination = undefined) {
     if (!(element instanceof HTMLElement)) {
         throw new Error('The provided element is not a valid HTMLElement.');
     }
 
-    let destination = selector
-        ? document.querySelector(selector)
-        : document.body;
+    if (destination instanceof HTMLElement) ; else if (typeof destination === 'string') {
+        destination = document.querySelector(destination);
+    } else {
+        destination = document.body;
+    }
 
     if (!destination) {
-        throw new Error(`No portal container with the given selector '${selector}' was found!`);
+        throw new Error('No portal destination was found.');
     }
 
     if (element.parentElement !== destination) {
@@ -1652,10 +1654,12 @@ async function initialize(id, options) {
         const arrowElement = popover.querySelector('[data-slot=arrow]');
         const ref = target.children.length === 1 ? target.firstElementChild : target;
 
-        portal(popover);
+        const closestDialog = popover.closest('dialog');
+
+        portal(popover, closestDialog);
 
         if (overlay) {
-            portal(overlay);
+            portal(overlay, closestDialog);
         }
 
         const {

--- a/src/LumexUI/wwwroot/js/components/popover.js
+++ b/src/LumexUI/wwwroot/js/components/popover.js
@@ -27,10 +27,12 @@ async function initialize(id, options) {
         const arrowElement = popover.querySelector('[data-slot=arrow]');
         const ref = target.children.length === 1 ? target.firstElementChild : target;
 
-        portal(popover);
+        const closestDialog = popover.closest('dialog');
+
+        portal(popover, closestDialog);
 
         if (overlay) {
-            portal(overlay);
+            portal(overlay, closestDialog);
         }
 
         const {

--- a/src/LumexUI/wwwroot/js/utils/dom.js
+++ b/src/LumexUI/wwwroot/js/utils/dom.js
@@ -22,17 +22,21 @@ export function waitForElement(selector) {
     });
 }
 
-export function portal(element, selector = undefined) {
+export function portal(element, destination = undefined) {
     if (!(element instanceof HTMLElement)) {
         throw new Error('The provided element is not a valid HTMLElement.');
     }
 
-    let destination = selector
-        ? document.querySelector(selector)
-        : document.body;
+    if (destination instanceof HTMLElement) {
+        // use it directly
+    } else if (typeof destination === 'string') {
+        destination = document.querySelector(destination);
+    } else {
+        destination = document.body;
+    }
 
     if (!destination) {
-        throw new Error(`No portal container with the given selector '${selector}' was found!`);
+        throw new Error('No portal destination was found.');
     }
 
     if (element.parentElement !== destination) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo! -->

## Description
<!--- 
    Provide a brief description of the changes in this pull request
    and mention related issues that this PR addresses or closes.
-->
Closes #299 

Popovers (used by LumexSelect, etc.) were portaled to `document.body`, which sits below the native `<dialog>` top layer. This made select dropdowns invisible when rendered inside a LumexModal.

### What's been done?
<!-- List the specific changes made in bullet-point format. -->

* Detect if the popover originates from within a `<dialog>`  element and portal into that dialog instead, keeping the popover within the top layer stacking context.
  
### Checklist
<!-- Make sure that you've checked all the items below before submitting the pull request. -->
- [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
- [x] I have included inline docs for my changes, where applicable.
- [x] I have added, updated or removed tests according to my changes.
- [x] All tests are passing.
- [x] There's an open issue for the PR that I am making.

### Additional Notes
<!-- 
    Any additional information that may be relevant to the 
    reviewer or the pull request as a whole. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popover rendering when used within dialog elements, with more reliable portal destination resolution and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->