### PR TITLE
fix(datebox): keep optional field valid after backspace clear

### DIFF
--- a/src/LumexUI/Components/Bases/LumexInputFieldBase.razor.cs
+++ b/src/LumexUI/Components/Bases/LumexInputFieldBase.razor.cs
@@ -235,7 +235,18 @@ public abstract partial class LumexInputFieldBase<TValue> : LumexInputBase<TValu
 	/// <inheritdoc />
 	protected override async ValueTask SetValidationMessageAsync()
 	{
-		ValidationMessage = await _jsModule.InvokeAsync<string>( "input.getValidationMessage", ElementReference );
+		// An empty value on a non-required field is valid by definition. Skip the native
+		// validity probe so transient `badInput` (e.g. a partially-cleared date input that
+		// reports value="" but validity.badInput=true) doesn't surface as an error.
+		if( !Required && !HasValue )
+		{
+			ValidationMessage = null;
+		}
+		else
+		{
+			ValidationMessage = await _jsModule.InvokeAsync<string>( "input.getValidationMessage", ElementReference );
+		}
+
 		Invalid = !string.IsNullOrEmpty( ErrorMessage ) ||
 				  !string.IsNullOrEmpty( ValidationMessage );
 	}

--- a/tests/LumexUI.Tests/Components/Datebox/DateboxTests.razor
+++ b/tests/LumexUI.Tests/Components/Datebox/DateboxTests.razor
@@ -4,12 +4,14 @@
 @using Microsoft.AspNetCore.Components.Web
 
 @code {
+    private readonly JSRuntimeInvocationHandler<string> _validationMessageHandler;
+
     public DateboxTests()
     {
         Services.AddSingleton<TwMerge>();
 
         var module = JSInterop.SetupModule("./_content/LumexUI/js/components/input.js");
-        module.Setup<string>("input.getValidationMessage", _ => true);
+        _validationMessageHandler = module.Setup<string>("input.getValidationMessage", _ => true);
     }
 
     [Fact]
@@ -219,5 +221,25 @@
         input.Input(value.ToString("yyyy-MM-dd"));
 
         cut.Instance.Value.Should().BeNull(because: "No-op");
+    }
+
+    [Fact]
+    public void ShouldStayValidWhenClearedAndNotRequired()
+    {
+        // Browsers report `validity.badInput` (and a non-empty validationMessage) on a
+        // partially-cleared date input even though `value` reads as empty. The component
+        // must treat an empty value on a non-required field as valid regardless.
+        _validationMessageHandler.SetResult("Please enter a valid value.");
+
+        var value = DateTime.Today;
+        var cut = Render<LumexDatebox<DateTime?>>(
+            @<LumexDatebox TValue="DateTime?" Clearable="@true" Required="@false" Value="@value" />
+        );
+
+        var input = cut.Find("input");
+        input.Change("");
+
+        cut.Instance.Value.Should().BeNull();
+        cut.Find("[data-slot=base]").GetAttribute("data-invalid").Should().Be("false");
     }
 }


### PR DESCRIPTION
## Description

Closes #301

When a `LumexDatebox` is bound to a nullable type with `Required="false"` and `Clearable="true"`, pressing Backspace to clear the field puts it into an error state instead of the expected valid empty state.

The browser's native `<input type="date">` is segmented (year/month/day). Backspacing one segment makes the value serialize to `""` per the HTML spec, but the input also gains `validity.badInput = true` with a non-empty `validationMessage` ("Please enter a valid value."). The component was unconditionally surfacing that native message via `LumexInputFieldBase.SetValidationMessageAsync`, so the field flipped to invalid even though the bound value parsed cleanly to `null`.

### What's been done?

* In `LumexInputFieldBase.SetValidationMessageAsync`, skip the native `validationMessage` probe when the field is non-required and empty — an empty value on an optional field is valid by definition. This also benefits `LumexNumbox` and `LumexTextbox`, which share the same base.
* Added a regression test (`ShouldStayValidWhenClearedAndNotRequired`) that simulates the browser returning a `badInput` message and asserts the cleared, non-required field stays valid (`data-invalid="false"`) with `Value == null`.

### Checklist
- [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
- [x] I have included inline docs for my changes, where applicable.
- [x] I have added, updated or removed tests according to my changes.
- [x] All tests are passing.
- [x] There's an open issue for the PR that I am making.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Non-required input fields now correctly display as valid when cleared, instead of potentially showing validation errors
* Improved validation handling for optional fields to properly recognize empty values as valid state

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LumexUI/lumexui/pull/307)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->