### PR TITLE
fix(modal): require pointerdown intent before backdrop dismiss

### DIFF
--- a/src/LumexUI/wwwroot/js/components/modal.js
+++ b/src/LumexUI/wwwroot/js/components/modal.js
@@ -5,27 +5,35 @@
 const instances = new Map();
 
 function initialize(element, dotNetRef) {
-    const clickHandler = (event) => {
-        const rect = element.getBoundingClientRect();
-        const isInDialog =
-            rect.top <= event.clientY &&
-            event.clientY <= rect.top + rect.height &&
-            rect.left <= event.clientX &&
-            event.clientX <= rect.left + rect.width;
+    // Only dismiss when both the pointerdown AND the click target the dialog
+    // itself (the ::backdrop pseudo-element bubbles to event.target === dialog).
+    // Coordinate-based checks misfire when a click bubbles up from inside the
+    // dialog with clientX/Y reported outside the dialog's bounding box — e.g.
+    // releasing a text-selection drag over the backdrop, or a native <select>
+    // dispatching a click whose coordinates sit outside the rect.
+    let pointerdownOnBackdrop = false;
 
-        if (!isInDialog) {
+    const pointerdownHandler = (event) => {
+        pointerdownOnBackdrop = event.target === element;
+    };
+
+    const clickHandler = (event) => {
+        if (event.target === element && pointerdownOnBackdrop) {
             element.close();
         }
+
+        pointerdownOnBackdrop = false;
     };
 
     const closeHandler = () => {
         dotNetRef.invokeMethodAsync("OnClose");
     };
 
+    element.addEventListener("pointerdown", pointerdownHandler);
     element.addEventListener("click", clickHandler);
     element.addEventListener("close", closeHandler);
 
-    instances.set(element, { clickHandler, closeHandler });
+    instances.set(element, { pointerdownHandler, clickHandler, closeHandler });
 }
 
 function open(element) {
@@ -44,6 +52,7 @@ function destroy(element) {
     const instance = instances.get(element);
 
     if (instance) {
+        element.removeEventListener("pointerdown", instance.pointerdownHandler);
         element.removeEventListener("click", instance.clickHandler);
         element.removeEventListener("close", instance.closeHandler);
         instances.delete(element);


### PR DESCRIPTION
## Description

Closes #304
Closes #306

`LumexModal` decided whether a click hit the backdrop by comparing the click's `clientX/Y` against the dialog's bounding rect. That check misfires whenever a `click` bubbles up from inside the dialog with coordinates reported outside the rect:

* **#304** — User mousedowns inside a `LumexTextbox`, drags to select text, releases over the backdrop. The browser dispatches a `click` on the dialog (closest common ancestor) with `clientX/Y` at the mouseup position, outside the rect → modal closes mid-text-selection.
* **#306** — User clicks a native `<select>` inside the modal. The bubbled `click` arrives at the dialog with `clientX/Y` outside the rect (option panel coords, or synthesized `(0, 0)` for keyboard-initiated commit) → modal closes despite the pointer never targeting the backdrop.

### What's been done?

* In `src/LumexUI/wwwroot/js/components/modal.js`, replace the bounding-rect coordinate check with the standard "mousedown intent" pattern: only dismiss when **both** the `pointerdown` and the `click` target the dialog element itself. The native `<dialog>::backdrop` is a pseudo-element of the dialog, so a real backdrop press surfaces as `event.target === dialog`; any interaction that originates inside the dialog content has a different target on `pointerdown` and is ignored.
* Tracked the new listener in the instances map and removed it in `destroy` to keep cleanup symmetric.

No JS-level test infrastructure exists in the repo, so the change is not covered by automated tests. The existing `ModalTests` (which mock `modal.js`) still pass. Manual verification of both repros recommended.

### Checklist
- [x] My code follows the project's [coding style and guidelines](https://github.com/LumexUI/lumexui/blob/main/src/CODING-STYLE.md).
- [x] I have included inline docs for my changes, where applicable.
- [ ] I have added, updated or removed tests according to my changes.
- [x] All tests are passing.
- [x] There's an open issue for the PR that I am making.

### Additional Notes

Manual repro steps to verify the fix:
* **#304** — Open any modal containing a `LumexTextbox`, click and drag inside the textbox to select text, release the mouse outside the modal. The modal should remain open.
* **#306** — Open a modal containing a native `<select>` (e.g. `Size="@ModalSize.Large"`, `ScrollBehavior="@ScrollBehavior.Inside"`), click the select to open its picker. The modal should remain open while interacting with the picker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal dismissal behavior when interacting with the backdrop for more reliable closing interactions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LumexUI/lumexui/pull/308)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->